### PR TITLE
feat: Organization management API layer

### DIFF
--- a/app/Client/HttpOrganizationClient.php
+++ b/app/Client/HttpOrganizationClient.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Client;
+
+use App\Contracts\OrganizationClient;
+use App\Data\CreateOrganizationData;
+use App\Data\OrganizationData;
+
+final readonly class HttpOrganizationClient implements OrganizationClient
+{
+    public function __construct(private LarakubeClient $client) {}
+
+    public function create(CreateOrganizationData $data): OrganizationData
+    {
+        $response = $this->client->post('/api/v1/organizations', [
+            'name' => $data->name,
+            'description' => $data->description,
+        ]);
+
+        return OrganizationData::fromArray($response->json('data'));
+    }
+
+    /**
+     * @return list<OrganizationData>
+     */
+    public function list(): array
+    {
+        $response = $this->client->get('/api/v1/organizations');
+
+        return array_map(
+            fn (array $item): OrganizationData => OrganizationData::fromArray($item),
+            $response->json('data'),
+        );
+    }
+}

--- a/app/Client/InMemoryOrganizationClient.php
+++ b/app/Client/InMemoryOrganizationClient.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Client;
+
+use App\Contracts\OrganizationClient;
+use App\Data\ApiErrorData;
+use App\Data\CreateOrganizationData;
+use App\Data\OrganizationData;
+use App\Enums\ApiErrorCode;
+use App\Exceptions\LarakubeApiException;
+
+final class InMemoryOrganizationClient implements OrganizationClient
+{
+    private ?OrganizationData $createResponse = null;
+
+    /** @var list<OrganizationData> */
+    private array $listResponse = [];
+
+    private bool $failCreate = false;
+
+    private bool $failList = false;
+
+    public function setCreateResponse(OrganizationData $data): void
+    {
+        $this->createResponse = $data;
+    }
+
+    public function shouldFailCreate(): void
+    {
+        $this->failCreate = true;
+    }
+
+    /**
+     * @param  list<OrganizationData>  $data
+     */
+    public function setListResponse(array $data): void
+    {
+        $this->listResponse = $data;
+    }
+
+    public function create(CreateOrganizationData $data): OrganizationData
+    {
+        if ($this->failCreate) {
+            throw new LarakubeApiException(new ApiErrorData(
+                message: 'Validation failed.',
+                code: ApiErrorCode::ValidationFailed,
+            ));
+        }
+
+        return $this->createResponse ?? new OrganizationData(
+            id: 'in-memory-id',
+            name: $data->name,
+            slug: str($data->name)->slug()->toString(),
+            description: $data->description,
+        );
+    }
+
+    public function shouldFailList(): void
+    {
+        $this->failList = true;
+    }
+
+    /**
+     * @return list<OrganizationData>
+     */
+    public function list(): array
+    {
+        if ($this->failList) {
+            throw new LarakubeApiException(new ApiErrorData(
+                message: 'Unauthenticated.',
+                code: ApiErrorCode::Unauthenticated,
+            ));
+        }
+
+        return $this->listResponse;
+    }
+}

--- a/app/Console/Commands/CreateOrganizationCommand.php
+++ b/app/Console/Commands/CreateOrganizationCommand.php
@@ -4,12 +4,11 @@ declare(strict_types=1);
 
 namespace App\Console\Commands;
 
-use App\Actions\CreateOrganization;
 use App\Console\Services\SessionManager;
+use App\Contracts\OrganizationClient;
 use App\Data\CreateOrganizationData;
 use App\Data\SessionOrganizationData;
-use App\Models\User;
-use Throwable;
+use App\Exceptions\LarakubeApiException;
 
 use function Laravel\Prompts\text;
 
@@ -25,7 +24,7 @@ final class CreateOrganizationCommand extends AuthenticatedCommand
      */
     protected $description = 'Create a new organization';
 
-    public function handleCommand(SessionManager $session, CreateOrganization $createOrganization): int
+    public function handleCommand(SessionManager $session, OrganizationClient $organizationClient): int
     {
         $name = $this->option('name') ?: text(
             label: 'Organization name',
@@ -36,18 +35,15 @@ final class CreateOrganizationCommand extends AuthenticatedCommand
             label: 'Description',
         );
 
-        $owner = User::query()->find($this->user->id);
-
         try {
-            $organization = $createOrganization->handle(
+            $organization = $organizationClient->create(
                 new CreateOrganizationData(
                     name: $name,
                     description: $description ?: null,
                 ),
-                $owner,
             );
-        } catch (Throwable $e) {
-            $this->components->error("Failed to create organization: {$e->getMessage()}");
+        } catch (LarakubeApiException $e) {
+            $this->components->error($e->getMessage());
 
             return self::FAILURE;
         }

--- a/app/Console/Commands/SelectOrganizationCommand.php
+++ b/app/Console/Commands/SelectOrganizationCommand.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace App\Console\Commands;
 
 use App\Console\Services\SessionManager;
+use App\Contracts\OrganizationClient;
 use App\Data\SessionOrganizationData;
-use App\Queries\OrganizationQuery;
-use App\Queries\UserQuery;
+use App\Exceptions\LarakubeApiException;
 
 use function Laravel\Prompts\select;
 
@@ -23,25 +23,39 @@ final class SelectOrganizationCommand extends AuthenticatedCommand
      */
     protected $description = 'Select an organization to work with';
 
-    public function handleCommand(SessionManager $session, UserQuery $userQuery, OrganizationQuery $organizationQuery): int
+    public function handleCommand(SessionManager $session, OrganizationClient $organizationClient): int
     {
-        $user = ($userQuery)()->byEmail($this->user->email)->first();
-        $organizations = ($organizationQuery)()->byUser($user)->get();
+        try {
+            $organizations = $organizationClient->list();
+        } catch (LarakubeApiException $e) {
+            $this->components->error($e->getMessage());
 
-        if ($organizations->isEmpty()) {
+            return self::FAILURE;
+        }
+
+        if ($organizations === []) {
             $this->components->error('You do not belong to any organizations. Run [organization:create] first.');
 
             return self::FAILURE;
         }
 
-        $choices = $organizations->pluck('name', 'id')->toArray();
+        $choices = [];
+        foreach ($organizations as $org) {
+            $choices[$org->id] = $org->name;
+        }
 
         $selectedId = select(
             label: 'Select an organization',
             options: $choices,
         );
 
-        $selected = $organizations->firstWhere('id', $selectedId);
+        $selected = null;
+        foreach ($organizations as $org) {
+            if ($org->id === $selectedId) {
+                $selected = $org;
+                break;
+            }
+        }
 
         $session->setOrganization(new SessionOrganizationData(
             id: $selected->id,

--- a/app/Contracts/OrganizationClient.php
+++ b/app/Contracts/OrganizationClient.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Contracts;
+
+use App\Data\CreateOrganizationData;
+use App\Data\OrganizationData;
+use App\Exceptions\LarakubeApiException;
+
+interface OrganizationClient
+{
+    /**
+     * @throws LarakubeApiException
+     */
+    public function create(CreateOrganizationData $data): OrganizationData;
+
+    /**
+     * @return list<OrganizationData>
+     *
+     * @throws LarakubeApiException
+     */
+    public function list(): array;
+}

--- a/app/Data/OrganizationData.php
+++ b/app/Data/OrganizationData.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Data;
+
+final readonly class OrganizationData
+{
+    public function __construct(
+        public string $id,
+        public string $name,
+        public string $slug,
+        public ?string $description = null,
+    ) {}
+
+    /**
+     * @param  array{id: string, name: string, slug: string, description?: string|null}  $data
+     */
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            id: $data['id'],
+            name: $data['name'],
+            slug: $data['slug'],
+            description: $data['description'] ?? null,
+        );
+    }
+
+    /**
+     * @return array{id: string, name: string, slug: string, description: string|null}
+     */
+    public function toArray(): array
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'slug' => $this->slug,
+            'description' => $this->description,
+        ];
+    }
+}

--- a/app/Enums/ApiErrorCode.php
+++ b/app/Enums/ApiErrorCode.php
@@ -8,6 +8,7 @@ enum ApiErrorCode: string
 {
     case InvalidCredentials = 'invalid_credentials';
     case Unauthenticated = 'unauthenticated';
+    case Forbidden = 'forbidden';
     case ValidationFailed = 'validation_failed';
     case NotFound = 'not_found';
 
@@ -15,6 +16,7 @@ enum ApiErrorCode: string
     {
         return match ($this) {
             self::InvalidCredentials, self::Unauthenticated => 401,
+            self::Forbidden => 403,
             self::ValidationFailed => 422,
             self::NotFound => 404,
         };

--- a/app/Http/Controllers/Api/V1/OrganizationController.php
+++ b/app/Http/Controllers/Api/V1/OrganizationController.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Actions\CreateOrganization;
+use App\Data\CreateOrganizationData;
+use App\Http\Requests\Api\V1\CreateOrganizationRequest;
+use App\Http\Resources\OrganizationResource;
+use App\Queries\OrganizationQuery;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+
+final class OrganizationController
+{
+    public function index(Request $request, OrganizationQuery $organizationQuery): AnonymousResourceCollection
+    {
+        $organizations = ($organizationQuery)()
+            ->byUser($request->user())
+            ->ordered()
+            ->get();
+
+        return OrganizationResource::collection($organizations);
+    }
+
+    public function store(CreateOrganizationRequest $request, CreateOrganization $createOrganization): JsonResponse
+    {
+        $organization = $createOrganization->handle(
+            new CreateOrganizationData(
+                name: $request->validated('name'),
+                description: $request->validated('description'),
+            ),
+            $request->user(),
+        );
+
+        return (new OrganizationResource($organization))
+            ->response()
+            ->setStatusCode(201);
+    }
+}

--- a/app/Http/Middleware/ResolveOrganization.php
+++ b/app/Http/Middleware/ResolveOrganization.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware;
+
+use App\Enums\ApiErrorCode;
+use App\Models\Organization;
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+final class ResolveOrganization
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        $organizationId = $request->header('X-Organization-Id');
+
+        if ($organizationId === null) {
+            return response()->json([
+                'message' => 'The X-Organization-Id header is required.',
+                'code' => ApiErrorCode::ValidationFailed->value,
+                'errors' => [],
+            ], ApiErrorCode::ValidationFailed->httpStatus());
+        }
+
+        $organization = Organization::query()->find($organizationId);
+
+        if ($organization === null) {
+            return response()->json([
+                'message' => 'Organization not found.',
+                'code' => ApiErrorCode::NotFound->value,
+                'errors' => [],
+            ], ApiErrorCode::NotFound->httpStatus());
+        }
+
+        if (! $request->user()->organizations()->where('organizations.id', $organization->id)->exists()) {
+            return response()->json([
+                'message' => 'You are not a member of this organization.',
+                'code' => ApiErrorCode::Forbidden->value,
+                'errors' => [],
+            ], ApiErrorCode::Forbidden->httpStatus());
+        }
+
+        $request->merge(['organization' => $organization]);
+
+        return $next($request);
+    }
+}

--- a/app/Http/Requests/Api/V1/CreateOrganizationRequest.php
+++ b/app/Http/Requests/Api/V1/CreateOrganizationRequest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Api\V1;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+final class CreateOrganizationRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, array<int, string>>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'description' => ['nullable', 'string', 'max:1000'],
+        ];
+    }
+}

--- a/app/Http/Resources/OrganizationResource.php
+++ b/app/Http/Resources/OrganizationResource.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources;
+
+use App\Models\Organization;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin Organization
+ */
+final class OrganizationResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'slug' => $this->slug,
+            'description' => $this->description,
+        ];
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace App\Providers;
 
 use App\Client\HttpAuthClient;
+use App\Client\HttpOrganizationClient;
 use App\Client\LarakubeClient;
 use App\Console\Services\SessionManager;
 use App\Contracts\AuthClient;
+use App\Contracts\OrganizationClient;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\ServiceProvider;
@@ -42,6 +44,7 @@ final class AppServiceProvider extends ServiceProvider
         });
 
         $this->app->bind(AuthClient::class, HttpAuthClient::class);
+        $this->app->bind(OrganizationClient::class, HttpOrganizationClient::class);
     }
 
     /**

--- a/routes/api.php
+++ b/routes/api.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Http\Controllers\Api\V1\AuthTokenController;
+use App\Http\Controllers\Api\V1\OrganizationController;
 use App\Http\Controllers\Api\V1\RegisterController;
 use Illuminate\Support\Facades\Route;
 
@@ -14,5 +15,11 @@ Route::prefix('v1')->as('api.v1.')->group(function (): void {
         Route::delete('token', [AuthTokenController::class, 'destroy'])
             ->middleware('auth:sanctum')
             ->name('token.destroy');
+    });
+
+    Route::middleware('auth:sanctum')->group(function (): void {
+        Route::apiResource('organizations', OrganizationController::class)
+            ->only(['index', 'store'])
+            ->names('organizations');
     });
 });

--- a/tests/Feature/Api/V1/OrganizationControllerTest.php
+++ b/tests/Feature/Api/V1/OrganizationControllerTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Organization;
+use App\Models\User;
+
+test('store creates an organization and returns organization data',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var User $user */
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user, 'sanctum')
+            ->postJson(route('api.v1.organizations.store'), [
+                'name' => 'Acme Corp',
+                'description' => 'A great company',
+            ]);
+
+        $response->assertCreated()
+            ->assertJsonStructure([
+                'data' => ['id', 'name', 'slug', 'description'],
+            ])
+            ->assertJsonPath('data.name', 'Acme Corp')
+            ->assertJsonPath('data.slug', 'acme-corp');
+
+        $this->assertDatabaseHas('organizations', ['name' => 'Acme Corp']);
+        $this->assertDatabaseHas('organization_user', [
+            'user_id' => $user->id,
+            'role' => 'owner',
+        ]);
+    });
+
+test('store validates required fields',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var User $user */
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user, 'sanctum')
+            ->postJson(route('api.v1.organizations.store'), []);
+
+        $response->assertUnprocessable()
+            ->assertJsonValidationErrors(['name']);
+    });
+
+test('store requires authentication',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        $response = $this->postJson(route('api.v1.organizations.store'), [
+            'name' => 'Acme Corp',
+        ]);
+
+        $response->assertUnauthorized();
+    });
+
+test('index returns organizations for authenticated user',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var User $user */
+        $user = User::factory()->create();
+
+        $org1 = Organization::factory()->create(['name' => 'Acme Corp']);
+        $org2 = Organization::factory()->create(['name' => 'Beta Inc']);
+        Organization::factory()->create(['name' => 'Other Corp']);
+
+        $user->organizations()->attach($org1, ['role' => 'owner']);
+        $user->organizations()->attach($org2, ['role' => 'member']);
+
+        $response = $this->actingAs($user, 'sanctum')
+            ->getJson(route('api.v1.organizations.index'));
+
+        $response->assertOk()
+            ->assertJsonCount(2, 'data')
+            ->assertJsonPath('data.0.name', 'Acme Corp')
+            ->assertJsonPath('data.1.name', 'Beta Inc');
+    });
+
+test('index returns empty array when user has no organizations',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var User $user */
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user, 'sanctum')
+            ->getJson(route('api.v1.organizations.index'));
+
+        $response->assertOk()
+            ->assertJsonCount(0, 'data');
+    });
+
+test('index requires authentication',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        $response = $this->getJson(route('api.v1.organizations.index'));
+
+        $response->assertUnauthorized();
+    });

--- a/tests/Feature/Commands/AuthenticatedCommandTest.php
+++ b/tests/Feature/Commands/AuthenticatedCommandTest.php
@@ -3,12 +3,17 @@
 declare(strict_types=1);
 
 use App\Actions\LoginUser;
+use App\Client\InMemoryOrganizationClient;
 use App\Console\Services\SessionManager;
+use App\Contracts\OrganizationClient;
+use App\Data\OrganizationData;
 use App\Models\Organization;
 use App\Models\User;
 
 beforeEach(function (): void {
     $this->app->singleton(SessionManager::class);
+    $this->organizationClient = new InMemoryOrganizationClient();
+    $this->app->instance(OrganizationClient::class, $this->organizationClient);
 });
 
 test('authenticated command blocks unauthenticated users',
@@ -37,6 +42,10 @@ test('authenticated command allows authenticated users',
         $userData = app(LoginUser::class)->handle('john@example.com', 'password123');
         $session = app(SessionManager::class);
         $session->setUser($userData);
+
+        $this->organizationClient->setListResponse([
+            new OrganizationData(id: $organization->id, name: $organization->name, slug: $organization->slug),
+        ]);
 
         $this->artisan('organization:select')
             ->expectsQuestion('Select an organization', $organization->id)

--- a/tests/Feature/Commands/CommandCoverageTest.php
+++ b/tests/Feature/Commands/CommandCoverageTest.php
@@ -3,7 +3,9 @@
 declare(strict_types=1);
 
 use App\Actions\LoginUser;
+use App\Client\InMemoryOrganizationClient;
 use App\Console\Services\SessionManager;
+use App\Contracts\OrganizationClient;
 use App\Data\SessionInfrastructureData;
 use App\Data\SessionOrganizationData;
 use App\Models\CloudProvider;
@@ -15,6 +17,8 @@ use Illuminate\Support\Facades\Http;
 
 beforeEach(function (): void {
     $this->app->singleton(SessionManager::class);
+    $this->organizationClient = new InMemoryOrganizationClient();
+    $this->app->instance(OrganizationClient::class, $this->organizationClient);
 });
 
 function setupAuthenticatedSession(object $test): array
@@ -171,14 +175,13 @@ test('server:delete shows message when no providers', function (): void {
 
 // CreateOrganizationCommand: error branch
 test('organization:create handles creation failure', function (): void {
-    [, $organization] = setupAuthenticatedSession($this);
+    setupAuthenticatedSession($this);
 
-    // Create org with same slug to trigger unique constraint
-    Organization::query()->create(['name' => 'Duplicate', 'slug' => 'duplicate']);
+    $this->organizationClient->shouldFailCreate();
 
     $this->artisan('organization:create')
         ->expectsQuestion('Organization name', 'Duplicate')
         ->expectsQuestion('Description', '')
-        ->expectsOutputToContain('Failed to create organization')
+        ->expectsOutputToContain('Validation failed.')
         ->assertFailed();
 });

--- a/tests/Feature/Commands/CreateOrganizationCommandTest.php
+++ b/tests/Feature/Commands/CreateOrganizationCommandTest.php
@@ -3,17 +3,21 @@
 declare(strict_types=1);
 
 use App\Actions\LoginUser;
+use App\Client\InMemoryOrganizationClient;
 use App\Console\Services\SessionManager;
+use App\Contracts\OrganizationClient;
+use App\Data\OrganizationData;
 use App\Models\User;
 
 beforeEach(function (): void {
     $this->app->singleton(SessionManager::class);
-    $this->loginUser = app(LoginUser::class);
+    $this->organizationClient = new InMemoryOrganizationClient();
+    $this->app->instance(OrganizationClient::class, $this->organizationClient);
 });
 
 test('create organization command creates org and auto-selects it',
     /**
-     * @throws Exception
+     * @throws Throwable
      */
     function (): void {
         /** @var User $user */
@@ -22,9 +26,16 @@ test('create organization command creates org and auto-selects it',
             'password' => 'password123',
         ]);
 
-        $userData = $this->loginUser->handle('john@example.com', 'password123');
+        $userData = app(LoginUser::class)->handle('john@example.com', 'password123');
         $session = app(SessionManager::class);
         $session->setUser($userData);
+
+        $this->organizationClient->setCreateResponse(new OrganizationData(
+            id: 'uuid-org-1',
+            name: 'Acme Corp',
+            slug: 'acme-corp',
+            description: 'A great company',
+        ));
 
         $this->artisan('organization:create')
             ->expectsQuestion('Organization name', 'Acme Corp')
@@ -32,14 +43,33 @@ test('create organization command creates org and auto-selects it',
             ->expectsOutputToContain('Organization [Acme Corp] created and selected')
             ->assertSuccessful();
 
-        $this->assertDatabaseHas('organizations', ['name' => 'Acme Corp']);
-        $this->assertDatabaseHas('organization_user', [
-            'user_id' => $user->id,
-            'role' => 'owner',
+        expect($session->hasOrganization())->toBeTrue()
+            ->and($session->getOrganization()->name)->toBe('Acme Corp')
+            ->and($session->getOrganization()->id)->toBe('uuid-org-1');
+    });
+
+test('create organization command displays error on failure',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var User $user */
+        $user = User::factory()->create([
+            'email' => 'john@example.com',
+            'password' => 'password123',
         ]);
 
-        expect($session->hasOrganization())->toBeTrue()
-            ->and($session->getOrganization()->name)->toBe('Acme Corp');
+        $userData = app(LoginUser::class)->handle('john@example.com', 'password123');
+        $session = app(SessionManager::class);
+        $session->setUser($userData);
+
+        $this->organizationClient->shouldFailCreate();
+
+        $this->artisan('organization:create')
+            ->expectsQuestion('Organization name', 'Acme Corp')
+            ->expectsQuestion('Description', '')
+            ->expectsOutputToContain('Validation failed.')
+            ->assertFailed();
     });
 
 test('create organization command fails when not authenticated',

--- a/tests/Feature/Commands/SelectOrganizationCommandTest.php
+++ b/tests/Feature/Commands/SelectOrganizationCommandTest.php
@@ -3,12 +3,16 @@
 declare(strict_types=1);
 
 use App\Actions\LoginUser;
+use App\Client\InMemoryOrganizationClient;
 use App\Console\Services\SessionManager;
-use App\Models\Organization;
+use App\Contracts\OrganizationClient;
+use App\Data\OrganizationData;
 use App\Models\User;
 
 beforeEach(function (): void {
     $this->app->singleton(SessionManager::class);
+    $this->organizationClient = new InMemoryOrganizationClient();
+    $this->app->instance(OrganizationClient::class, $this->organizationClient);
 });
 
 test('select organization command lists and persists selection',
@@ -16,25 +20,29 @@ test('select organization command lists and persists selection',
      * @throws Throwable
      */
     function (): void {
+        /** @var User $user */
         $user = User::factory()->create([
             'email' => 'john@example.com',
             'password' => 'password123',
         ]);
 
-        $organization = Organization::factory()->create(['name' => 'Acme Corp']);
-        $user->organizations()->attach($organization, ['role' => 'member']);
-
         $userData = app(LoginUser::class)->handle('john@example.com', 'password123');
         $session = app(SessionManager::class);
         $session->setUser($userData);
 
+        $this->organizationClient->setListResponse([
+            new OrganizationData(id: 'uuid-org-1', name: 'Acme Corp', slug: 'acme-corp'),
+            new OrganizationData(id: 'uuid-org-2', name: 'Beta Inc', slug: 'beta-inc'),
+        ]);
+
         $this->artisan('organization:select')
-            ->expectsQuestion('Select an organization', $organization->id)
+            ->expectsQuestion('Select an organization', 'uuid-org-1')
             ->expectsOutputToContain('Selected organization [Acme Corp]')
             ->assertSuccessful();
 
         expect($session->hasOrganization())->toBeTrue()
-            ->and($session->getOrganization()->id)->toBe($organization->id);
+            ->and($session->getOrganization()->id)->toBe('uuid-org-1')
+            ->and($session->getOrganization()->name)->toBe('Acme Corp');
     });
 
 test('select organization command fails when user has no orgs',
@@ -42,6 +50,7 @@ test('select organization command fails when user has no orgs',
      * @throws Throwable
      */
     function (): void {
+        /** @var User $user */
         $user = User::factory()->create([
             'email' => 'john@example.com',
             'password' => 'password123',
@@ -53,6 +62,28 @@ test('select organization command fails when user has no orgs',
 
         $this->artisan('organization:select')
             ->expectsOutputToContain('You do not belong to any organizations')
+            ->assertFailed();
+    });
+
+test('select organization command displays error on api failure',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var User $user */
+        $user = User::factory()->create([
+            'email' => 'john@example.com',
+            'password' => 'password123',
+        ]);
+
+        $userData = app(LoginUser::class)->handle('john@example.com', 'password123');
+        $session = app(SessionManager::class);
+        $session->setUser($userData);
+
+        $this->organizationClient->shouldFailList();
+
+        $this->artisan('organization:select')
+            ->expectsOutputToContain('Unauthenticated.')
             ->assertFailed();
     });
 

--- a/tests/Feature/Middleware/ResolveOrganizationTest.php
+++ b/tests/Feature/Middleware/ResolveOrganizationTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Http\Middleware\ResolveOrganization;
+use App\Models\Organization;
+use App\Models\User;
+use Illuminate\Support\Facades\Route;
+
+beforeEach(function (): void {
+    Route::middleware(['auth:sanctum', ResolveOrganization::class])
+        ->get('/test/org-middleware', fn () => response()->json(['ok' => true]));
+});
+
+test('resolves organization from header',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var User $user */
+        $user = User::factory()->create();
+        $org = Organization::factory()->create();
+        $user->organizations()->attach($org, ['role' => 'member']);
+
+        $response = $this->actingAs($user, 'sanctum')
+            ->withHeaders(['X-Organization-Id' => $org->id])
+            ->getJson('/test/org-middleware');
+
+        $response->assertOk();
+    });
+
+test('returns 422 when header is missing',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var User $user */
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user, 'sanctum')
+            ->getJson('/test/org-middleware');
+
+        $response->assertUnprocessable()
+            ->assertJsonPath('code', 'validation_failed');
+    });
+
+test('returns 403 when user is not a member',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var User $user */
+        $user = User::factory()->create();
+        $org = Organization::factory()->create();
+
+        $response = $this->actingAs($user, 'sanctum')
+            ->withHeaders(['X-Organization-Id' => $org->id])
+            ->getJson('/test/org-middleware');
+
+        $response->assertForbidden()
+            ->assertJsonPath('code', 'forbidden');
+    });
+
+test('returns 404 when organization does not exist',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var User $user */
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user, 'sanctum')
+            ->withHeaders(['X-Organization-Id' => 'non-existent-id'])
+            ->getJson('/test/org-middleware');
+
+        $response->assertNotFound()
+            ->assertJsonPath('code', 'not_found');
+    });

--- a/tests/Unit/Client/HttpOrganizationClientTest.php
+++ b/tests/Unit/Client/HttpOrganizationClientTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Client\HttpOrganizationClient;
+use App\Client\LarakubeClient;
+use App\Data\CreateOrganizationData;
+use App\Data\OrganizationData;
+use Illuminate\Support\Facades\Http;
+
+beforeEach(function (): void {
+    $this->larakubeClient = new LarakubeClient(
+        baseUrl: 'http://localhost:8000',
+        token: '1|abc123',
+    );
+
+    $this->client = new HttpOrganizationClient($this->larakubeClient);
+});
+
+test('create returns organization data',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        Http::fake([
+            '*/api/v1/organizations' => Http::response([
+                'data' => [
+                    'id' => 'uuid-123',
+                    'name' => 'Acme Corp',
+                    'slug' => 'acme-corp',
+                    'description' => 'A great company',
+                ],
+            ], 201),
+        ]);
+
+        $result = $this->client->create(new CreateOrganizationData(
+            name: 'Acme Corp',
+            description: 'A great company',
+        ));
+
+        expect($result)
+            ->toBeInstanceOf(OrganizationData::class)
+            ->id->toBe('uuid-123')
+            ->name->toBe('Acme Corp')
+            ->slug->toBe('acme-corp');
+    });
+
+test('list returns array of organization data',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        Http::fake([
+            '*/api/v1/organizations' => Http::response([
+                'data' => [
+                    ['id' => 'uuid-1', 'name' => 'Acme', 'slug' => 'acme', 'description' => null],
+                    ['id' => 'uuid-2', 'name' => 'Beta', 'slug' => 'beta', 'description' => null],
+                ],
+            ]),
+        ]);
+
+        $result = $this->client->list();
+
+        expect($result)->toHaveCount(2)
+            ->and($result[0])->toBeInstanceOf(OrganizationData::class)
+            ->and($result[0]->name)->toBe('Acme')
+            ->and($result[1]->name)->toBe('Beta');
+    });

--- a/tests/Unit/Client/InMemoryOrganizationClientTest.php
+++ b/tests/Unit/Client/InMemoryOrganizationClientTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Client\InMemoryOrganizationClient;
+use App\Data\CreateOrganizationData;
+use App\Data\OrganizationData;
+use App\Exceptions\LarakubeApiException;
+
+beforeEach(function (): void {
+    $this->client = new InMemoryOrganizationClient();
+});
+
+test('create returns configured organization data',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        $orgData = new OrganizationData(id: 'uuid-1', name: 'Acme', slug: 'acme');
+        $this->client->setCreateResponse($orgData);
+
+        $result = $this->client->create(new CreateOrganizationData(name: 'Acme'));
+
+        expect($result)->toBe($orgData);
+    });
+
+test('create throws when configured to fail',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        $this->client->shouldFailCreate();
+
+        $this->client->create(new CreateOrganizationData(name: 'Acme'));
+    })->throws(LarakubeApiException::class);
+
+test('list returns configured organizations',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        $orgs = [
+            new OrganizationData(id: 'uuid-1', name: 'Acme', slug: 'acme'),
+            new OrganizationData(id: 'uuid-2', name: 'Beta', slug: 'beta'),
+        ];
+        $this->client->setListResponse($orgs);
+
+        $result = $this->client->list();
+
+        expect($result)->toBe($orgs);
+    });
+
+test('list returns empty array by default',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        $result = $this->client->list();
+
+        expect($result)->toBe([]);
+    });

--- a/tests/Unit/Data/OrganizationDataTest.php
+++ b/tests/Unit/Data/OrganizationDataTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Data\OrganizationData;
+
+test('constructor sets properties', function (): void {
+    $data = new OrganizationData(
+        id: 'uuid-123',
+        name: 'Acme Corp',
+        slug: 'acme-corp',
+        description: 'A great company',
+    );
+
+    expect($data)
+        ->id->toBe('uuid-123')
+        ->name->toBe('Acme Corp')
+        ->slug->toBe('acme-corp')
+        ->description->toBe('A great company');
+});
+
+test('fromArray and toArray round-trip', function (): void {
+    $original = [
+        'id' => 'uuid-123',
+        'name' => 'Acme Corp',
+        'slug' => 'acme-corp',
+        'description' => 'A great company',
+    ];
+
+    $data = OrganizationData::fromArray($original);
+
+    expect($data->toArray())->toBe($original);
+});
+
+test('description defaults to null', function (): void {
+    $data = OrganizationData::fromArray([
+        'id' => 'uuid-123',
+        'name' => 'Acme',
+        'slug' => 'acme',
+    ]);
+
+    expect($data->description)->toBeNull();
+});


### PR DESCRIPTION
## Summary

- Adds `POST /api/v1/organizations` and `GET /api/v1/organizations` endpoints with `OrganizationController` (store, index)
- Adds `ResolveOrganization` middleware that reads `X-Organization-Id` header, verifies user membership, and binds org to request (returns 422/403/404 on failure)
- Adds `Forbidden` case to `ApiErrorCode` enum
- Introduces `OrganizationClient` contract with `HttpOrganizationClient` and `InMemoryOrganizationClient` implementations
- Adds `OrganizationData` response DTO and `OrganizationResource` JSON resource
- Rewires `organization:create` and `organization:select` commands to use `OrganizationClient` instead of direct Action/Query calls

Closes #4

## Test plan

- [x] 380 tests passing (787 assertions)
- [x] 100% code coverage
- [x] 100% type coverage
- [x] Pint clean
- [x] API endpoint tests for organization create and list (auth, validation, membership scoping)
- [x] Middleware tests for ResolveOrganization (missing header, not found, forbidden, success)
- [x] HTTP client tests with `Http::fake()`
- [x] InMemory client tests for controllable test doubles
- [x] Command tests using InMemory clients
- [x] OrganizationData DTO round-trip tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)