### PR TITLE
feat: Cloud Provider management API layer

### DIFF
--- a/app/Client/HttpCloudProviderClient.php
+++ b/app/Client/HttpCloudProviderClient.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Client;
+
+use App\Contracts\CloudProviderClient;
+use App\Data\CloudProviderData;
+use App\Data\CreateCloudProviderData;
+
+final readonly class HttpCloudProviderClient implements CloudProviderClient
+{
+    public function __construct(private LarakubeClient $client) {}
+
+    public function create(CreateCloudProviderData $data): CloudProviderData
+    {
+        $response = $this->client->post('/api/v1/cloud-providers', [
+            'name' => $data->name,
+            'type' => $data->type->value,
+            'api_token' => $data->apiToken,
+        ]);
+
+        return CloudProviderData::fromArray($response->json('data'));
+    }
+
+    /**
+     * @return list<CloudProviderData>
+     */
+    public function list(): array
+    {
+        $response = $this->client->get('/api/v1/cloud-providers');
+
+        return array_map(
+            CloudProviderData::fromArray(...),
+            $response->json('data'),
+        );
+    }
+
+    public function delete(string $id): void
+    {
+        $this->client->delete("/api/v1/cloud-providers/{$id}");
+    }
+}

--- a/app/Client/HttpOrganizationClient.php
+++ b/app/Client/HttpOrganizationClient.php
@@ -30,7 +30,7 @@ final readonly class HttpOrganizationClient implements OrganizationClient
         $response = $this->client->get('/api/v1/organizations');
 
         return array_map(
-            fn (array $item): OrganizationData => OrganizationData::fromArray($item),
+            OrganizationData::fromArray(...),
             $response->json('data'),
         );
     }

--- a/app/Client/InMemoryCloudProviderClient.php
+++ b/app/Client/InMemoryCloudProviderClient.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Client;
+
+use App\Contracts\CloudProviderClient;
+use App\Data\ApiErrorData;
+use App\Data\CloudProviderData;
+use App\Data\CreateCloudProviderData;
+use App\Enums\ApiErrorCode;
+use App\Exceptions\LarakubeApiException;
+
+final class InMemoryCloudProviderClient implements CloudProviderClient
+{
+    public bool $deleteCalled = false;
+
+    public ?string $deletedId = null;
+
+    private ?CloudProviderData $createResponse = null;
+
+    /** @var list<CloudProviderData> */
+    private array $listResponse = [];
+
+    private bool $failCreate = false;
+
+    private bool $failList = false;
+
+    private bool $failDelete = false;
+
+    public function setCreateResponse(CloudProviderData $data): void
+    {
+        $this->createResponse = $data;
+    }
+
+    public function shouldFailCreate(): void
+    {
+        $this->failCreate = true;
+    }
+
+    /**
+     * @param  list<CloudProviderData>  $data
+     */
+    public function setListResponse(array $data): void
+    {
+        $this->listResponse = $data;
+    }
+
+    public function shouldFailDelete(): void
+    {
+        $this->failDelete = true;
+    }
+
+    public function create(CreateCloudProviderData $data): CloudProviderData
+    {
+        if ($this->failCreate) {
+            throw new LarakubeApiException(new ApiErrorData(
+                message: 'The API token for '.$data->type->label().' is invalid.',
+                code: ApiErrorCode::ValidationFailed,
+            ));
+        }
+
+        return $this->createResponse ?? new CloudProviderData(
+            id: 'in-memory-id',
+            name: $data->name,
+            type: $data->type->value,
+            isVerified: true,
+        );
+    }
+
+    public function shouldFailList(): void
+    {
+        $this->failList = true;
+    }
+
+    /**
+     * @return list<CloudProviderData>
+     */
+    public function list(): array
+    {
+        if ($this->failList) {
+            throw new LarakubeApiException(new ApiErrorData(
+                message: 'Unauthenticated.',
+                code: ApiErrorCode::Unauthenticated,
+            ));
+        }
+
+        return $this->listResponse;
+    }
+
+    public function delete(string $id): void
+    {
+        if ($this->failDelete) {
+            throw new LarakubeApiException(new ApiErrorData(
+                message: 'Failed to delete cloud provider.',
+                code: ApiErrorCode::NotFound,
+            ));
+        }
+
+        $this->deleteCalled = true;
+        $this->deletedId = $id;
+    }
+}

--- a/app/Console/Commands/AddCloudProviderCommand.php
+++ b/app/Console/Commands/AddCloudProviderCommand.php
@@ -4,11 +4,10 @@ declare(strict_types=1);
 
 namespace App\Console\Commands;
 
-use App\Actions\CreateCloudProvider;
+use App\Contracts\CloudProviderClient;
 use App\Data\CreateCloudProviderData;
 use App\Enums\CloudProviderType;
-use App\Models\Organization;
-use Throwable;
+use App\Exceptions\LarakubeApiException;
 use ValueError;
 
 use function Laravel\Prompts\password;
@@ -29,7 +28,7 @@ final class AddCloudProviderCommand extends AuthenticatedCommand
 
     protected bool $requiresOrganization = true;
 
-    public function handleCommand(CreateCloudProvider $createCloudProvider): int
+    public function handleCommand(CloudProviderClient $cloudProviderClient): int
     {
         $typeOption = $this->option('type');
 
@@ -68,20 +67,17 @@ final class AddCloudProviderCommand extends AuthenticatedCommand
             required: true,
         );
 
-        $organization = Organization::query()->find($this->organization->id);
-
         $this->components->info('Validating API token...');
 
         try {
-            $cloudProvider = $createCloudProvider->handle(
+            $cloudProvider = $cloudProviderClient->create(
                 new CreateCloudProviderData(
                     name: $name,
                     type: $type,
                     apiToken: $apiToken,
                 ),
-                $organization,
             );
-        } catch (Throwable $e) {
+        } catch (LarakubeApiException $e) {
             $this->components->error($e->getMessage());
 
             return self::FAILURE;

--- a/app/Console/Commands/ListCloudProvidersCommand.php
+++ b/app/Console/Commands/ListCloudProvidersCommand.php
@@ -4,9 +4,10 @@ declare(strict_types=1);
 
 namespace App\Console\Commands;
 
-use App\Models\CloudProvider;
-use App\Models\Organization;
-use App\Queries\CloudProviderQuery;
+use App\Contracts\CloudProviderClient;
+use App\Data\CloudProviderData;
+use App\Enums\CloudProviderType;
+use App\Exceptions\LarakubeApiException;
 
 final class ListCloudProvidersCommand extends AuthenticatedCommand
 {
@@ -22,25 +23,29 @@ final class ListCloudProvidersCommand extends AuthenticatedCommand
 
     protected bool $requiresOrganization = true;
 
-    public function handleCommand(CloudProviderQuery $cloudProviderQuery): int
+    public function handleCommand(CloudProviderClient $cloudProviderClient): int
     {
-        $organization = Organization::query()->find($this->organization->id);
-        $providers = ($cloudProviderQuery)()->byOrganization($organization)->get();
+        try {
+            $providers = $cloudProviderClient->list();
+        } catch (LarakubeApiException $e) {
+            $this->components->error($e->getMessage());
 
-        if ($providers->isEmpty()) {
+            return self::FAILURE;
+        }
+
+        if ($providers === []) {
             $this->components->info('No cloud providers configured. Run [cloud-provider:add] to add one.');
 
             return self::SUCCESS;
         }
 
         $this->table(
-            ['Name', 'Type', 'Verified', 'Created'],
-            $providers->map(fn (CloudProvider $provider) => [
+            ['Name', 'Type', 'Verified'],
+            array_map(fn (CloudProviderData $provider): array => [
                 $provider->name,
-                $provider->type->label(),
-                $provider->is_verified ? 'Yes' : 'No',
-                $provider->created_at->format('Y-m-d H:i'),
-            ]),
+                CloudProviderType::from($provider->type)->label(),
+                $provider->isVerified ? 'Yes' : 'No',
+            ], $providers),
         );
 
         return self::SUCCESS;

--- a/app/Console/Commands/RemoveCloudProviderCommand.php
+++ b/app/Console/Commands/RemoveCloudProviderCommand.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace App\Console\Commands;
 
-use App\Models\CloudProvider;
-use App\Models\Organization;
-use App\Queries\CloudProviderQuery;
+use App\Contracts\CloudProviderClient;
+use App\Enums\CloudProviderType;
+use App\Exceptions\LarakubeApiException;
 
 use function Laravel\Prompts\confirm;
 use function Laravel\Prompts\select;
@@ -25,27 +25,39 @@ final class RemoveCloudProviderCommand extends AuthenticatedCommand
 
     protected bool $requiresOrganization = true;
 
-    public function handleCommand(CloudProviderQuery $cloudProviderQuery): int
+    public function handleCommand(CloudProviderClient $cloudProviderClient): int
     {
-        $organization = Organization::query()->find($this->organization->id);
-        $providers = ($cloudProviderQuery)()->byOrganization($organization)->get();
+        try {
+            $providers = $cloudProviderClient->list();
+        } catch (LarakubeApiException $e) {
+            $this->components->error($e->getMessage());
 
-        if ($providers->isEmpty()) {
+            return self::FAILURE;
+        }
+
+        if ($providers === []) {
             $this->components->info('No cloud providers to remove.');
 
             return self::SUCCESS;
         }
 
-        $choices = $providers->mapWithKeys(fn (CloudProvider $provider) => [
-            $provider->id => "{$provider->name} ({$provider->type->label()})",
-        ])->toArray();
+        $choices = [];
+        foreach ($providers as $provider) {
+            $choices[$provider->id] = "{$provider->name} (".CloudProviderType::from($provider->type)->label().')';
+        }
 
         $selectedId = select(
             label: 'Select a cloud provider to remove',
             options: $choices,
         );
 
-        $selected = $providers->firstWhere('id', $selectedId);
+        $selected = null;
+        foreach ($providers as $provider) {
+            if ($provider->id === $selectedId) {
+                $selected = $provider;
+                break;
+            }
+        }
 
         if (! confirm("Are you sure you want to remove [{$selected->name}]?")) {
             $this->components->info('Cancelled.');
@@ -53,7 +65,13 @@ final class RemoveCloudProviderCommand extends AuthenticatedCommand
             return self::SUCCESS;
         }
 
-        $selected->delete();
+        try {
+            $cloudProviderClient->delete($selected->id);
+        } catch (LarakubeApiException $e) {
+            $this->components->error($e->getMessage());
+
+            return self::FAILURE;
+        }
 
         $this->components->info("Cloud provider [{$selected->name}] removed.");
 

--- a/app/Contracts/CloudProviderClient.php
+++ b/app/Contracts/CloudProviderClient.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Contracts;
+
+use App\Data\CloudProviderData;
+use App\Data\CreateCloudProviderData;
+use App\Exceptions\LarakubeApiException;
+
+interface CloudProviderClient
+{
+    /**
+     * @throws LarakubeApiException
+     */
+    public function create(CreateCloudProviderData $data): CloudProviderData;
+
+    /**
+     * @return list<CloudProviderData>
+     *
+     * @throws LarakubeApiException
+     */
+    public function list(): array;
+
+    /**
+     * @throws LarakubeApiException
+     */
+    public function delete(string $id): void;
+}

--- a/app/Data/CloudProviderData.php
+++ b/app/Data/CloudProviderData.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Data;
+
+final readonly class CloudProviderData
+{
+    public function __construct(
+        public string $id,
+        public string $name,
+        public string $type,
+        public bool $isVerified,
+    ) {}
+
+    /**
+     * @param  array{id: string, name: string, type: string, is_verified: bool}  $data
+     */
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            id: $data['id'],
+            name: $data['name'],
+            type: $data['type'],
+            isVerified: $data['is_verified'],
+        );
+    }
+
+    /**
+     * @return array{id: string, name: string, type: string, is_verified: bool}
+     */
+    public function toArray(): array
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'type' => $this->type,
+            'is_verified' => $this->isVerified,
+        ];
+    }
+}

--- a/app/Http/Controllers/Api/V1/CloudProviderController.php
+++ b/app/Http/Controllers/Api/V1/CloudProviderController.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Actions\CreateCloudProvider;
+use App\Data\CreateCloudProviderData;
+use App\Enums\ApiErrorCode;
+use App\Enums\CloudProviderType;
+use App\Http\Requests\Api\V1\CreateCloudProviderRequest;
+use App\Http\Resources\CloudProviderResource;
+use App\Models\CloudProvider;
+use App\Queries\CloudProviderQuery;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use Illuminate\Http\Response;
+use RuntimeException;
+
+final class CloudProviderController
+{
+    public function index(Request $request, CloudProviderQuery $cloudProviderQuery): AnonymousResourceCollection
+    {
+        $providers = ($cloudProviderQuery)()
+            ->byOrganization($request->organization)
+            ->ordered()
+            ->get();
+
+        return CloudProviderResource::collection($providers);
+    }
+
+    public function store(CreateCloudProviderRequest $request, CreateCloudProvider $createCloudProvider): JsonResponse
+    {
+        try {
+            $cloudProvider = $createCloudProvider->handle(
+                new CreateCloudProviderData(
+                    name: $request->validated('name'),
+                    type: CloudProviderType::from($request->validated('type')),
+                    apiToken: $request->validated('api_token'),
+                ),
+                $request->organization,
+            );
+        } catch (RuntimeException $e) {
+            return response()->json([
+                'message' => $e->getMessage(),
+                'code' => ApiErrorCode::ValidationFailed->value,
+                'errors' => [],
+            ], ApiErrorCode::ValidationFailed->httpStatus());
+        }
+
+        return (new CloudProviderResource($cloudProvider))
+            ->response()
+            ->setStatusCode(201);
+    }
+
+    public function destroy(Request $request, CloudProvider $cloudProvider): Response
+    {
+        $cloudProvider->delete();
+
+        return response()->noContent();
+    }
+}

--- a/app/Http/Requests/Api/V1/CreateCloudProviderRequest.php
+++ b/app/Http/Requests/Api/V1/CreateCloudProviderRequest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Api\V1;
+
+use App\Enums\CloudProviderType;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+final class CreateCloudProviderRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, array<int, mixed>>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'type' => ['required', 'string', Rule::enum(CloudProviderType::class)],
+            'api_token' => ['required', 'string'],
+        ];
+    }
+}

--- a/app/Http/Resources/CloudProviderResource.php
+++ b/app/Http/Resources/CloudProviderResource.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources;
+
+use App\Models\CloudProvider;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin CloudProvider
+ */
+final class CloudProviderResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'type' => $this->type->value,
+            'is_verified' => $this->is_verified,
+        ];
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -5,10 +5,12 @@ declare(strict_types=1);
 namespace App\Providers;
 
 use App\Client\HttpAuthClient;
+use App\Client\HttpCloudProviderClient;
 use App\Client\HttpOrganizationClient;
 use App\Client\LarakubeClient;
 use App\Console\Services\SessionManager;
 use App\Contracts\AuthClient;
+use App\Contracts\CloudProviderClient;
 use App\Contracts\OrganizationClient;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Database\Eloquent\Model;
@@ -45,6 +47,7 @@ final class AppServiceProvider extends ServiceProvider
 
         $this->app->bind(AuthClient::class, HttpAuthClient::class);
         $this->app->bind(OrganizationClient::class, HttpOrganizationClient::class);
+        $this->app->bind(CloudProviderClient::class, HttpCloudProviderClient::class);
     }
 
     /**

--- a/routes/api.php
+++ b/routes/api.php
@@ -3,8 +3,10 @@
 declare(strict_types=1);
 
 use App\Http\Controllers\Api\V1\AuthTokenController;
+use App\Http\Controllers\Api\V1\CloudProviderController;
 use App\Http\Controllers\Api\V1\OrganizationController;
 use App\Http\Controllers\Api\V1\RegisterController;
+use App\Http\Middleware\ResolveOrganization;
 use Illuminate\Support\Facades\Route;
 
 Route::prefix('v1')->as('api.v1.')->group(function (): void {
@@ -21,5 +23,11 @@ Route::prefix('v1')->as('api.v1.')->group(function (): void {
         Route::apiResource('organizations', OrganizationController::class)
             ->only(['index', 'store'])
             ->names('organizations');
+
+        Route::middleware(ResolveOrganization::class)->group(function (): void {
+            Route::apiResource('cloud-providers', CloudProviderController::class)
+                ->only(['index', 'store', 'destroy'])
+                ->names('cloud-providers');
+        });
     });
 });

--- a/tests/Feature/Api/V1/CloudProviderControllerTest.php
+++ b/tests/Feature/Api/V1/CloudProviderControllerTest.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\CloudProvider;
+use App\Models\Organization;
+use App\Models\User;
+
+beforeEach(function (): void {
+    /** @var User $user */
+    $this->user = User::factory()->create();
+    $this->organization = Organization::factory()->create();
+    $this->user->organizations()->attach($this->organization, ['role' => 'owner']);
+
+    $hetznerService = useInMemoryHetznerService(true);
+    bindInMemoryHetznerFactory($hetznerService);
+});
+
+test('store creates a cloud provider and returns data',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        $response = $this->actingAs($this->user, 'sanctum')
+            ->withHeaders(['X-Organization-Id' => $this->organization->id])
+            ->postJson(route('api.v1.cloud-providers.store'), [
+                'name' => 'Hetzner Production',
+                'type' => 'hetzner',
+                'api_token' => 'valid-token',
+            ]);
+
+        $response->assertCreated()
+            ->assertJsonStructure([
+                'data' => ['id', 'name', 'type', 'is_verified'],
+            ])
+            ->assertJsonPath('data.name', 'Hetzner Production')
+            ->assertJsonPath('data.type', 'hetzner')
+            ->assertJsonPath('data.is_verified', true);
+
+        $this->assertDatabaseHas('cloud_providers', [
+            'organization_id' => $this->organization->id,
+            'name' => 'Hetzner Production',
+        ]);
+    });
+
+test('store fails with invalid token',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        $hetznerService = useInMemoryHetznerService(false);
+        bindInMemoryHetznerFactory($hetznerService);
+
+        $response = $this->actingAs($this->user, 'sanctum')
+            ->withHeaders(['X-Organization-Id' => $this->organization->id])
+            ->postJson(route('api.v1.cloud-providers.store'), [
+                'name' => 'Hetzner Staging',
+                'type' => 'hetzner',
+                'api_token' => 'invalid-token',
+            ]);
+
+        $response->assertUnprocessable()
+            ->assertJsonPath('message', 'The API token for Hetzner is invalid.');
+    });
+
+test('store validates required fields',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        $response = $this->actingAs($this->user, 'sanctum')
+            ->withHeaders(['X-Organization-Id' => $this->organization->id])
+            ->postJson(route('api.v1.cloud-providers.store'), []);
+
+        $response->assertUnprocessable()
+            ->assertJsonValidationErrors(['name', 'type', 'api_token']);
+    });
+
+test('index returns cloud providers for organization',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        CloudProvider::factory()->hetzner()->create([
+            'organization_id' => $this->organization->id,
+            'name' => 'Hetzner Production',
+        ]);
+
+        $otherOrg = Organization::factory()->create();
+        CloudProvider::factory()->hetzner()->create([
+            'organization_id' => $otherOrg->id,
+            'name' => 'Other Provider',
+        ]);
+
+        $response = $this->actingAs($this->user, 'sanctum')
+            ->withHeaders(['X-Organization-Id' => $this->organization->id])
+            ->getJson(route('api.v1.cloud-providers.index'));
+
+        $response->assertOk()
+            ->assertJsonCount(1, 'data')
+            ->assertJsonPath('data.0.name', 'Hetzner Production');
+    });
+
+test('destroy deletes a cloud provider',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        $provider = CloudProvider::factory()->hetzner()->create([
+            'organization_id' => $this->organization->id,
+        ]);
+
+        $response = $this->actingAs($this->user, 'sanctum')
+            ->withHeaders(['X-Organization-Id' => $this->organization->id])
+            ->deleteJson(route('api.v1.cloud-providers.destroy', $provider));
+
+        $response->assertNoContent();
+
+        $this->assertDatabaseMissing('cloud_providers', ['id' => $provider->id]);
+    });
+
+test('all endpoints require authentication',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        $this->postJson(route('api.v1.cloud-providers.store'))->assertUnauthorized();
+        $this->getJson(route('api.v1.cloud-providers.index'))->assertUnauthorized();
+        $this->deleteJson(route('api.v1.cloud-providers.destroy', 'fake-id'))->assertUnauthorized();
+    });
+
+test('all endpoints require organization header',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        $this->actingAs($this->user, 'sanctum')
+            ->postJson(route('api.v1.cloud-providers.store'))
+            ->assertUnprocessable()
+            ->assertJsonPath('code', 'validation_failed');
+
+        $this->actingAs($this->user, 'sanctum')
+            ->getJson(route('api.v1.cloud-providers.index'))
+            ->assertUnprocessable();
+    });

--- a/tests/Feature/Commands/AddCloudProviderCommandTest.php
+++ b/tests/Feature/Commands/AddCloudProviderCommandTest.php
@@ -3,16 +3,18 @@
 declare(strict_types=1);
 
 use App\Actions\LoginUser;
+use App\Client\InMemoryCloudProviderClient;
 use App\Console\Services\SessionManager;
+use App\Contracts\CloudProviderClient;
+use App\Data\CloudProviderData;
 use App\Data\SessionOrganizationData;
 use App\Models\Organization;
 use App\Models\User;
 
 beforeEach(function (): void {
     $this->app->singleton(SessionManager::class);
-
-    /** @var LoginUser $this->loginUser */
-    $this->loginUser = app(LoginUser::class);
+    $this->cloudProviderClient = new InMemoryCloudProviderClient();
+    $this->app->instance(CloudProviderClient::class, $this->cloudProviderClient);
 });
 
 test('add cloud provider command creates provider with valid token',
@@ -20,10 +22,6 @@ test('add cloud provider command creates provider with valid token',
      * @throws Throwable
      */
     function (): void {
-        $hetznerService = useInMemoryHetznerService(true);
-
-        bindInMemoryHetznerFactory($hetznerService);
-
         /** @var User $user */
         $user = User::factory()->create([
             'email' => 'john@example.com',
@@ -34,13 +32,20 @@ test('add cloud provider command creates provider with valid token',
         $organization = Organization::factory()->create();
         $organization->users()->attach($user, ['role' => 'owner']);
 
-        $userData = $this->loginUser->handle('john@example.com', 'password123');
+        $userData = app(LoginUser::class)->handle('john@example.com', 'password123');
         $session = app(SessionManager::class);
         $session->setUser($userData);
         $session->setOrganization(new SessionOrganizationData(
             id: $organization->id,
             name: $organization->name,
             slug: $organization->slug,
+        ));
+
+        $this->cloudProviderClient->setCreateResponse(new CloudProviderData(
+            id: 'uuid-cp-1',
+            name: 'Hetzner Production',
+            type: 'hetzner',
+            isVerified: true,
         ));
 
         $this->artisan('cloud-provider:add')
@@ -49,13 +54,6 @@ test('add cloud provider command creates provider with valid token',
             ->expectsQuestion('API token', 'valid-token')
             ->expectsOutputToContain('Cloud provider [Hetzner Production] added successfully')
             ->assertSuccessful();
-
-        $this->assertDatabaseHas('cloud_providers', [
-            'organization_id' => $organization->id,
-            'name' => 'Hetzner Production',
-            'type' => 'hetzner',
-            'is_verified' => true,
-        ]);
     });
 
 test('add cloud provider command fails with invalid token',
@@ -63,10 +61,6 @@ test('add cloud provider command fails with invalid token',
      * @throws Throwable
      */
     function (): void {
-        $hetznerService = useInMemoryHetznerService(false);
-
-        bindInMemoryHetznerFactory($hetznerService);
-
         /** @var User $user */
         $user = User::factory()->create([
             'email' => 'john@example.com',
@@ -77,7 +71,7 @@ test('add cloud provider command fails with invalid token',
         $organization = Organization::factory()->create();
         $organization->users()->attach($user, ['role' => 'owner']);
 
-        $userData = $this->loginUser->handle('john@example.com', 'password123');
+        $userData = app(LoginUser::class)->handle('john@example.com', 'password123');
         $session = app(SessionManager::class);
         $session->setUser($userData);
         $session->setOrganization(new SessionOrganizationData(
@@ -85,6 +79,8 @@ test('add cloud provider command fails with invalid token',
             name: $organization->name,
             slug: $organization->slug,
         ));
+
+        $this->cloudProviderClient->shouldFailCreate();
 
         $this->artisan('cloud-provider:add')
             ->expectsQuestion('Select a cloud provider', 'hetzner')
@@ -119,7 +115,7 @@ test('add cloud provider command fails with invalid provider type from CLI optio
         $organization = Organization::factory()->create();
         $organization->users()->attach($user, ['role' => 'owner']);
 
-        $userData = $this->loginUser->handle('john@example.com', 'password123');
+        $userData = app(LoginUser::class)->handle('john@example.com', 'password123');
         $session = app(SessionManager::class);
         $session->setUser($userData);
         $session->setOrganization(new SessionOrganizationData(

--- a/tests/Feature/Commands/ListCloudProvidersCommandTest.php
+++ b/tests/Feature/Commands/ListCloudProvidersCommandTest.php
@@ -3,14 +3,18 @@
 declare(strict_types=1);
 
 use App\Actions\LoginUser;
+use App\Client\InMemoryCloudProviderClient;
 use App\Console\Services\SessionManager;
+use App\Contracts\CloudProviderClient;
+use App\Data\CloudProviderData;
 use App\Data\SessionOrganizationData;
-use App\Models\CloudProvider;
 use App\Models\Organization;
 use App\Models\User;
 
 beforeEach(function (): void {
     $this->app->singleton(SessionManager::class);
+    $this->cloudProviderClient = new InMemoryCloudProviderClient();
+    $this->app->instance(CloudProviderClient::class, $this->cloudProviderClient);
 });
 
 test('list cloud providers shows table of providers',
@@ -18,18 +22,15 @@ test('list cloud providers shows table of providers',
      * @throws Throwable
      */
     function (): void {
+        /** @var User $user */
         $user = User::factory()->create([
             'email' => 'john@example.com',
             'password' => 'password123',
         ]);
 
+        /** @var Organization $organization */
         $organization = Organization::factory()->create();
         $organization->users()->attach($user, ['role' => 'owner']);
-
-        CloudProvider::factory()->hetzner()->create([
-            'organization_id' => $organization->id,
-            'name' => 'Hetzner Production',
-        ]);
 
         $userData = app(LoginUser::class)->handle('john@example.com', 'password123');
         $session = app(SessionManager::class);
@@ -39,6 +40,10 @@ test('list cloud providers shows table of providers',
             name: $organization->name,
             slug: $organization->slug,
         ));
+
+        $this->cloudProviderClient->setListResponse([
+            new CloudProviderData(id: 'uuid-1', name: 'Hetzner Production', type: 'hetzner', isVerified: true),
+        ]);
 
         $this->artisan('cloud-provider:list')
             ->expectsOutputToContain('Hetzner Production')
@@ -50,11 +55,13 @@ test('list cloud providers shows message when none exist',
      * @throws Throwable
      */
     function (): void {
+        /** @var User $user */
         $user = User::factory()->create([
             'email' => 'john@example.com',
             'password' => 'password123',
         ]);
 
+        /** @var Organization $organization */
         $organization = Organization::factory()->create();
         $organization->users()->attach($user, ['role' => 'owner']);
 
@@ -70,4 +77,35 @@ test('list cloud providers shows message when none exist',
         $this->artisan('cloud-provider:list')
             ->expectsOutputToContain('No cloud providers configured')
             ->assertSuccessful();
+    });
+
+test('list cloud providers displays error on api failure',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var User $user */
+        $user = User::factory()->create([
+            'email' => 'john@example.com',
+            'password' => 'password123',
+        ]);
+
+        /** @var Organization $organization */
+        $organization = Organization::factory()->create();
+        $organization->users()->attach($user, ['role' => 'owner']);
+
+        $userData = app(LoginUser::class)->handle('john@example.com', 'password123');
+        $session = app(SessionManager::class);
+        $session->setUser($userData);
+        $session->setOrganization(new SessionOrganizationData(
+            id: $organization->id,
+            name: $organization->name,
+            slug: $organization->slug,
+        ));
+
+        $this->cloudProviderClient->shouldFailList();
+
+        $this->artisan('cloud-provider:list')
+            ->expectsOutputToContain('Unauthenticated.')
+            ->assertFailed();
     });

--- a/tests/Feature/Commands/RemoveCloudProviderCommandTest.php
+++ b/tests/Feature/Commands/RemoveCloudProviderCommandTest.php
@@ -3,16 +3,18 @@
 declare(strict_types=1);
 
 use App\Actions\LoginUser;
+use App\Client\InMemoryCloudProviderClient;
 use App\Console\Services\SessionManager;
+use App\Contracts\CloudProviderClient;
+use App\Data\CloudProviderData;
 use App\Data\SessionOrganizationData;
-use App\Models\CloudProvider;
 use App\Models\Organization;
 use App\Models\User;
 
 beforeEach(function (): void {
-
-    $tempPath = sys_get_temp_dir().'/remove-cloud-provider-test-'.uniqid().'/session.json';
     $this->app->singleton(SessionManager::class);
+    $this->cloudProviderClient = new InMemoryCloudProviderClient();
+    $this->app->instance(CloudProviderClient::class, $this->cloudProviderClient);
 });
 
 test('remove cloud provider deletes the selected provider',
@@ -20,18 +22,15 @@ test('remove cloud provider deletes the selected provider',
      * @throws Throwable
      */
     function (): void {
+        /** @var User $user */
         $user = User::factory()->create([
             'email' => 'john@example.com',
             'password' => 'password123',
         ]);
 
+        /** @var Organization $organization */
         $organization = Organization::factory()->create();
         $organization->users()->attach($user, ['role' => 'owner']);
-
-        $cloudProvider = CloudProvider::factory()->hetzner()->create([
-            'organization_id' => $organization->id,
-            'name' => 'Hetzner Production',
-        ]);
 
         $userData = app(LoginUser::class)->handle('john@example.com', 'password123');
         $session = app(SessionManager::class);
@@ -42,13 +41,18 @@ test('remove cloud provider deletes the selected provider',
             slug: $organization->slug,
         ));
 
+        $this->cloudProviderClient->setListResponse([
+            new CloudProviderData(id: 'uuid-cp-1', name: 'Hetzner Production', type: 'hetzner', isVerified: true),
+        ]);
+
         $this->artisan('cloud-provider:remove')
-            ->expectsQuestion('Select a cloud provider to remove', $cloudProvider->id)
-            ->expectsConfirmation("Are you sure you want to remove [{$cloudProvider->name}]?", 'yes')
+            ->expectsQuestion('Select a cloud provider to remove', 'uuid-cp-1')
+            ->expectsConfirmation('Are you sure you want to remove [Hetzner Production]?', 'yes')
             ->expectsOutputToContain('Cloud provider [Hetzner Production] removed')
             ->assertSuccessful();
 
-        $this->assertDatabaseMissing('cloud_providers', ['id' => $cloudProvider->id]);
+        expect($this->cloudProviderClient->deleteCalled)->toBeTrue()
+            ->and($this->cloudProviderClient->deletedId)->toBe('uuid-cp-1');
     });
 
 test('remove cloud provider shows message when none exist',
@@ -56,11 +60,13 @@ test('remove cloud provider shows message when none exist',
      * @throws Throwable
      */
     function (): void {
+        /** @var User $user */
         $user = User::factory()->create([
             'email' => 'john@example.com',
             'password' => 'password123',
         ]);
 
+        /** @var Organization $organization */
         $organization = Organization::factory()->create();
         $organization->users()->attach($user, ['role' => 'owner']);
 
@@ -83,18 +89,15 @@ test('remove cloud provider cancels when user declines confirmation',
      * @throws Throwable
      */
     function (): void {
+        /** @var User $user */
         $user = User::factory()->create([
             'email' => 'john@example.com',
             'password' => 'password123',
         ]);
 
+        /** @var Organization $organization */
         $organization = Organization::factory()->create();
         $organization->users()->attach($user, ['role' => 'owner']);
-
-        $cloudProvider = CloudProvider::factory()->hetzner()->create([
-            'organization_id' => $organization->id,
-            'name' => 'Hetzner Production',
-        ]);
 
         $userData = app(LoginUser::class)->handle('john@example.com', 'password123');
         $session = app(SessionManager::class);
@@ -105,11 +108,82 @@ test('remove cloud provider cancels when user declines confirmation',
             slug: $organization->slug,
         ));
 
+        $this->cloudProviderClient->setListResponse([
+            new CloudProviderData(id: 'uuid-cp-1', name: 'Hetzner Production', type: 'hetzner', isVerified: true),
+        ]);
+
         $this->artisan('cloud-provider:remove')
-            ->expectsQuestion('Select a cloud provider to remove', $cloudProvider->id)
-            ->expectsConfirmation("Are you sure you want to remove [{$cloudProvider->name}]?", 'no')
+            ->expectsQuestion('Select a cloud provider to remove', 'uuid-cp-1')
+            ->expectsConfirmation('Are you sure you want to remove [Hetzner Production]?', 'no')
             ->expectsOutputToContain('Cancelled')
             ->assertSuccessful();
 
-        $this->assertDatabaseHas('cloud_providers', ['id' => $cloudProvider->id]);
+        expect($this->cloudProviderClient->deleteCalled)->toBeFalse();
+    });
+
+test('remove cloud provider displays error on list failure',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var User $user */
+        $user = User::factory()->create([
+            'email' => 'john@example.com',
+            'password' => 'password123',
+        ]);
+
+        /** @var Organization $organization */
+        $organization = Organization::factory()->create();
+        $organization->users()->attach($user, ['role' => 'owner']);
+
+        $userData = app(LoginUser::class)->handle('john@example.com', 'password123');
+        $session = app(SessionManager::class);
+        $session->setUser($userData);
+        $session->setOrganization(new SessionOrganizationData(
+            id: $organization->id,
+            name: $organization->name,
+            slug: $organization->slug,
+        ));
+
+        $this->cloudProviderClient->shouldFailList();
+
+        $this->artisan('cloud-provider:remove')
+            ->expectsOutputToContain('Unauthenticated.')
+            ->assertFailed();
+    });
+
+test('remove cloud provider displays error on delete failure',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var User $user */
+        $user = User::factory()->create([
+            'email' => 'john@example.com',
+            'password' => 'password123',
+        ]);
+
+        /** @var Organization $organization */
+        $organization = Organization::factory()->create();
+        $organization->users()->attach($user, ['role' => 'owner']);
+
+        $userData = app(LoginUser::class)->handle('john@example.com', 'password123');
+        $session = app(SessionManager::class);
+        $session->setUser($userData);
+        $session->setOrganization(new SessionOrganizationData(
+            id: $organization->id,
+            name: $organization->name,
+            slug: $organization->slug,
+        ));
+
+        $this->cloudProviderClient->setListResponse([
+            new CloudProviderData(id: 'uuid-cp-1', name: 'Hetzner Production', type: 'hetzner', isVerified: true),
+        ]);
+        $this->cloudProviderClient->shouldFailDelete();
+
+        $this->artisan('cloud-provider:remove')
+            ->expectsQuestion('Select a cloud provider to remove', 'uuid-cp-1')
+            ->expectsConfirmation('Are you sure you want to remove [Hetzner Production]?', 'yes')
+            ->expectsOutputToContain('Failed to delete cloud provider.')
+            ->assertFailed();
     });

--- a/tests/Unit/Client/HttpCloudProviderClientTest.php
+++ b/tests/Unit/Client/HttpCloudProviderClientTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Client\HttpCloudProviderClient;
+use App\Client\LarakubeClient;
+use App\Data\CloudProviderData;
+use App\Data\CreateCloudProviderData;
+use App\Enums\CloudProviderType;
+use Illuminate\Support\Facades\Http;
+
+beforeEach(function (): void {
+    $this->client = new HttpCloudProviderClient(
+        new LarakubeClient(baseUrl: 'http://localhost:8000', token: '1|abc', organizationId: 'org-1'),
+    );
+});
+
+test('create returns cloud provider data',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        Http::fake([
+            '*/api/v1/cloud-providers' => Http::response([
+                'data' => ['id' => 'uuid-1', 'name' => 'Hetzner', 'type' => 'hetzner', 'is_verified' => true],
+            ], 201),
+        ]);
+
+        $result = $this->client->create(new CreateCloudProviderData(
+            name: 'Hetzner',
+            type: CloudProviderType::Hetzner,
+            apiToken: 'token',
+        ));
+
+        expect($result)
+            ->toBeInstanceOf(CloudProviderData::class)
+            ->name->toBe('Hetzner');
+    });
+
+test('list returns array of cloud provider data',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        Http::fake([
+            '*/api/v1/cloud-providers' => Http::response([
+                'data' => [
+                    ['id' => 'uuid-1', 'name' => 'Hetzner', 'type' => 'hetzner', 'is_verified' => true],
+                ],
+            ]),
+        ]);
+
+        $result = $this->client->list();
+
+        expect($result)->toHaveCount(1)
+            ->and($result[0]->name)->toBe('Hetzner');
+    });
+
+test('delete sends delete request',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        Http::fake([
+            '*/api/v1/cloud-providers/*' => Http::response(null, 204),
+        ]);
+
+        $this->client->delete('uuid-1');
+
+        Http::assertSent(fn ($request): bool => $request->method() === 'DELETE'
+            && str_contains((string) $request->url(), '/api/v1/cloud-providers/uuid-1'));
+    });

--- a/tests/Unit/Client/InMemoryCloudProviderClientTest.php
+++ b/tests/Unit/Client/InMemoryCloudProviderClientTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Client\InMemoryCloudProviderClient;
+use App\Data\CloudProviderData;
+use App\Data\CreateCloudProviderData;
+use App\Enums\CloudProviderType;
+use App\Exceptions\LarakubeApiException;
+
+beforeEach(function (): void {
+    $this->client = new InMemoryCloudProviderClient();
+});
+
+test('create returns configured data',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        $data = new CloudProviderData(id: 'uuid-1', name: 'Hetzner', type: 'hetzner', isVerified: true);
+        $this->client->setCreateResponse($data);
+
+        $result = $this->client->create(new CreateCloudProviderData(
+            name: 'Hetzner',
+            type: CloudProviderType::Hetzner,
+            apiToken: 'token',
+        ));
+
+        expect($result)->toBe($data);
+    });
+
+test('create throws when configured to fail',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        $this->client->shouldFailCreate();
+
+        $this->client->create(new CreateCloudProviderData(
+            name: 'Hetzner',
+            type: CloudProviderType::Hetzner,
+            apiToken: 'token',
+        ));
+    })->throws(LarakubeApiException::class);
+
+test('list returns configured data',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        $providers = [
+            new CloudProviderData(id: 'uuid-1', name: 'Hetzner', type: 'hetzner', isVerified: true),
+        ];
+        $this->client->setListResponse($providers);
+
+        expect($this->client->list())->toBe($providers);
+    });
+
+test('delete tracks the call',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        $this->client->delete('uuid-1');
+
+        expect($this->client->deleteCalled)->toBeTrue()
+            ->and($this->client->deletedId)->toBe('uuid-1');
+    });
+
+test('delete throws when configured to fail',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        $this->client->shouldFailDelete();
+
+        $this->client->delete('uuid-1');
+    })->throws(LarakubeApiException::class);

--- a/tests/Unit/Data/CloudProviderDataTest.php
+++ b/tests/Unit/Data/CloudProviderDataTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Data\CloudProviderData;
+
+test('constructor sets properties', function (): void {
+    $data = new CloudProviderData(
+        id: 'uuid-1',
+        name: 'Hetzner Production',
+        type: 'hetzner',
+        isVerified: true,
+    );
+
+    expect($data)
+        ->id->toBe('uuid-1')
+        ->name->toBe('Hetzner Production')
+        ->type->toBe('hetzner')
+        ->isVerified->toBeTrue();
+});
+
+test('fromArray and toArray round-trip', function (): void {
+    $original = [
+        'id' => 'uuid-1',
+        'name' => 'Hetzner Production',
+        'type' => 'hetzner',
+        'is_verified' => true,
+    ];
+
+    $data = CloudProviderData::fromArray($original);
+
+    expect($data->toArray())->toBe($original);
+});


### PR DESCRIPTION
## Summary

- Adds `POST /api/v1/cloud-providers`, `GET /api/v1/cloud-providers`, and `DELETE /api/v1/cloud-providers/{id}` endpoints with `CloudProviderController`
- All endpoints require `auth:sanctum` + `ResolveOrganization` middleware
- Introduces `CloudProviderClient` contract with `HttpCloudProviderClient` and `InMemoryCloudProviderClient` implementations
- Adds `CloudProviderData` response DTO and `CloudProviderResource` JSON resource
- Rewires `cloud-provider:add`, `cloud-provider:list`, `cloud-provider:remove` commands to use `CloudProviderClient` instead of direct Action/Query calls
- Fixes `CloudProviderController::store()` return type (was `CloudProviderResource|JsonResponse`, now `JsonResponse`)

Closes #5

## Test plan

- [x] 400 tests passing (840 assertions)
- [x] 100% code coverage
- [x] 100% type coverage
- [x] Pint clean
- [x] API endpoint tests for cloud provider CRUD (auth, validation, org scoping, token validation)
- [x] HTTP client tests with `Http::fake()`
- [x] InMemory client tests for controllable test doubles
- [x] Command tests using InMemory clients (all 3 commands + error paths)
- [x] CloudProviderData DTO round-trip tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)