### PR TITLE
feat: Infrastructure management API layer

### DIFF
--- a/app/Client/HttpInfrastructureClient.php
+++ b/app/Client/HttpInfrastructureClient.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Client;
+
+use App\Contracts\InfrastructureClient;
+use App\Data\CreateInfrastructureData;
+use App\Data\InfrastructureData;
+
+final readonly class HttpInfrastructureClient implements InfrastructureClient
+{
+    public function __construct(private LarakubeClient $client) {}
+
+    public function create(CreateInfrastructureData $data, string $cloudProviderId): InfrastructureData
+    {
+        $response = $this->client->post('/api/v1/infrastructures', [
+            'name' => $data->name,
+            'description' => $data->description,
+            'cloud_provider_id' => $cloudProviderId,
+        ]);
+
+        return InfrastructureData::fromArray($response->json('data'));
+    }
+
+    /**
+     * @return list<InfrastructureData>
+     */
+    public function list(): array
+    {
+        $response = $this->client->get('/api/v1/infrastructures');
+
+        return array_map(
+            InfrastructureData::fromArray(...),
+            $response->json('data'),
+        );
+    }
+}

--- a/app/Client/InMemoryInfrastructureClient.php
+++ b/app/Client/InMemoryInfrastructureClient.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Client;
+
+use App\Contracts\InfrastructureClient;
+use App\Data\ApiErrorData;
+use App\Data\CreateInfrastructureData;
+use App\Data\InfrastructureData;
+use App\Enums\ApiErrorCode;
+use App\Exceptions\LarakubeApiException;
+
+final class InMemoryInfrastructureClient implements InfrastructureClient
+{
+    private ?InfrastructureData $createResponse = null;
+
+    /** @var list<InfrastructureData> */
+    private array $listResponse = [];
+
+    private bool $failCreate = false;
+
+    private bool $failList = false;
+
+    public function setCreateResponse(InfrastructureData $data): void
+    {
+        $this->createResponse = $data;
+    }
+
+    public function shouldFailCreate(): void
+    {
+        $this->failCreate = true;
+    }
+
+    /**
+     * @param  list<InfrastructureData>  $data
+     */
+    public function setListResponse(array $data): void
+    {
+        $this->listResponse = $data;
+    }
+
+    public function shouldFailList(): void
+    {
+        $this->failList = true;
+    }
+
+    public function create(CreateInfrastructureData $data, string $cloudProviderId): InfrastructureData
+    {
+        if ($this->failCreate) {
+            throw new LarakubeApiException(new ApiErrorData(
+                message: 'Validation failed.',
+                code: ApiErrorCode::ValidationFailed,
+            ));
+        }
+
+        return $this->createResponse ?? new InfrastructureData(
+            id: 'in-memory-id',
+            name: $data->name,
+            description: $data->description,
+            status: 'healthy',
+            cloudProviderId: $cloudProviderId,
+        );
+    }
+
+    /**
+     * @return list<InfrastructureData>
+     */
+    public function list(): array
+    {
+        if ($this->failList) {
+            throw new LarakubeApiException(new ApiErrorData(
+                message: 'Unauthenticated.',
+                code: ApiErrorCode::Unauthenticated,
+            ));
+        }
+
+        return $this->listResponse;
+    }
+}

--- a/app/Console/Commands/CreateInfrastructureCommand.php
+++ b/app/Console/Commands/CreateInfrastructureCommand.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace App\Console\Commands;
 
-use App\Actions\CreateInfrastructure;
+use App\Contracts\CloudProviderClient;
+use App\Contracts\InfrastructureClient;
 use App\Data\CreateInfrastructureData;
-use App\Models\CloudProvider;
-use App\Models\Organization;
-use App\Queries\CloudProviderQuery;
+use App\Enums\CloudProviderType;
+use App\Exceptions\LarakubeApiException;
 
 use function Laravel\Prompts\select;
 use function Laravel\Prompts\text;
@@ -27,12 +27,17 @@ final class CreateInfrastructureCommand extends AuthenticatedCommand
 
     protected bool $requiresOrganization = true;
 
-    public function handleCommand(CreateInfrastructure $createInfrastructure, CloudProviderQuery $cloudProviderQuery): int
+    public function handleCommand(InfrastructureClient $infrastructureClient, CloudProviderClient $cloudProviderClient): int
     {
-        $organization = Organization::query()->find($this->organization->id);
-        $providers = ($cloudProviderQuery)()->byOrganization($organization)->get();
+        try {
+            $providers = $cloudProviderClient->list();
+        } catch (LarakubeApiException $e) {
+            $this->components->error($e->getMessage());
 
-        if ($providers->isEmpty()) {
+            return self::FAILURE;
+        }
+
+        if ($providers === []) {
             $this->components->info('No cloud providers configured. Run [cloud-provider:add] first.');
 
             return self::SUCCESS;
@@ -41,23 +46,36 @@ final class CreateInfrastructureCommand extends AuthenticatedCommand
         $providerOption = $this->option('provider');
 
         if ($providerOption) {
-            $provider = $providers->firstWhere('id', $providerOption);
-            if (! $provider) {
+            $provider = null;
+            foreach ($providers as $p) {
+                if ($p->id === $providerOption) {
+                    $provider = $p;
+                    break;
+                }
+            }
+            if ($provider === null) {
                 $this->components->error('Provider not found.');
 
                 return self::FAILURE;
             }
         } else {
-            $choices = $providers->mapWithKeys(fn (CloudProvider $provider) => [
-                $provider->id => "{$provider->name} ({$provider->type->label()})",
-            ])->toArray();
+            $choices = [];
+            foreach ($providers as $p) {
+                $choices[$p->id] = "{$p->name} (".CloudProviderType::from($p->type)->label().')';
+            }
 
             $providerId = select(
                 label: 'Select a cloud provider',
                 options: $choices,
             );
 
-            $provider = $providers->firstWhere('id', $providerId);
+            $provider = null;
+            foreach ($providers as $p) {
+                if ($p->id === $providerId) {
+                    $provider = $p;
+                    break;
+                }
+            }
         }
 
         $nameOption = $this->option('name');
@@ -71,13 +89,19 @@ final class CreateInfrastructureCommand extends AuthenticatedCommand
             label: 'Description (optional)',
         );
 
-        $infrastructure = $createInfrastructure->handle(
-            $provider,
-            new CreateInfrastructureData(
-                name: $name,
-                description: $description ?: null,
-            ),
-        );
+        try {
+            $infrastructure = $infrastructureClient->create(
+                new CreateInfrastructureData(
+                    name: $name,
+                    description: $description ?: null,
+                ),
+                $provider->id,
+            );
+        } catch (LarakubeApiException $e) {
+            $this->components->error($e->getMessage());
+
+            return self::FAILURE;
+        }
 
         $this->components->info("Infrastructure [{$infrastructure->name}] created successfully.");
 

--- a/app/Console/Commands/SelectInfrastructureCommand.php
+++ b/app/Console/Commands/SelectInfrastructureCommand.php
@@ -5,11 +5,12 @@ declare(strict_types=1);
 namespace App\Console\Commands;
 
 use App\Console\Services\SessionManager;
+use App\Contracts\CloudProviderClient;
+use App\Contracts\InfrastructureClient;
+use App\Data\InfrastructureData;
 use App\Data\SessionInfrastructureData;
-use App\Models\CloudProvider;
-use App\Models\Organization;
-use App\Queries\CloudProviderQuery;
-use App\Queries\InfrastructureQuery;
+use App\Enums\CloudProviderType;
+use App\Exceptions\LarakubeApiException;
 
 use function Laravel\Prompts\select;
 
@@ -27,43 +28,72 @@ final class SelectInfrastructureCommand extends AuthenticatedCommand
 
     protected bool $requiresOrganization = true;
 
-    public function handleCommand(SessionManager $session, CloudProviderQuery $cloudProviderQuery, InfrastructureQuery $infrastructureQuery): int
-    {
-        $organization = Organization::query()->find($this->organization->id);
-        $providers = ($cloudProviderQuery)()->byOrganization($organization)->get();
+    public function handleCommand(
+        SessionManager $session,
+        CloudProviderClient $cloudProviderClient,
+        InfrastructureClient $infrastructureClient,
+    ): int {
+        try {
+            $providers = $cloudProviderClient->list();
+        } catch (LarakubeApiException $e) {
+            $this->components->error($e->getMessage());
 
-        if ($providers->isEmpty()) {
+            return self::FAILURE;
+        }
+
+        if ($providers === []) {
             $this->components->error('No cloud providers configured. Run [cloud-provider:add] first.');
 
             return self::FAILURE;
         }
 
-        $choices = $providers->mapWithKeys(fn (CloudProvider $provider) => [
-            $provider->id => "{$provider->name} ({$provider->type->label()})",
-        ])->toArray();
+        $choices = [];
+        foreach ($providers as $provider) {
+            $choices[$provider->id] = "{$provider->name} (".CloudProviderType::from($provider->type)->label().')';
+        }
 
         $providerId = select(
             label: 'Select a cloud provider',
             options: $choices,
         );
 
-        $provider = $providers->firstWhere('id', $providerId);
-        $infrastructures = ($infrastructureQuery)()->byProvider($provider)->get();
+        try {
+            $infrastructures = $infrastructureClient->list();
+        } catch (LarakubeApiException $e) {
+            $this->components->error($e->getMessage());
 
-        if ($infrastructures->isEmpty()) {
+            return self::FAILURE;
+        }
+
+        // Filter to selected provider
+        $filtered = array_values(array_filter(
+            $infrastructures,
+            fn (InfrastructureData $infra): bool => $infra->cloudProviderId === $providerId,
+        ));
+
+        if ($filtered === []) {
             $this->components->error('No infrastructures configured. Run [infrastructure:create] first.');
 
             return self::FAILURE;
         }
 
-        $infraChoices = $infrastructures->pluck('name', 'id')->toArray();
+        $infraChoices = [];
+        foreach ($filtered as $infra) {
+            $infraChoices[$infra->id] = $infra->name;
+        }
 
         $selectedId = select(
             label: 'Select an infrastructure',
             options: $infraChoices,
         );
 
-        $selected = $infrastructures->firstWhere('id', $selectedId);
+        $selected = null;
+        foreach ($filtered as $infra) {
+            if ($infra->id === $selectedId) {
+                $selected = $infra;
+                break;
+            }
+        }
 
         $session->setInfrastructure(new SessionInfrastructureData(
             id: $selected->id,

--- a/app/Contracts/InfrastructureClient.php
+++ b/app/Contracts/InfrastructureClient.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Contracts;
+
+use App\Data\CreateInfrastructureData;
+use App\Data\InfrastructureData;
+use App\Exceptions\LarakubeApiException;
+
+interface InfrastructureClient
+{
+    /**
+     * @throws LarakubeApiException
+     */
+    public function create(CreateInfrastructureData $data, string $cloudProviderId): InfrastructureData;
+
+    /**
+     * @return list<InfrastructureData>
+     *
+     * @throws LarakubeApiException
+     */
+    public function list(): array;
+}

--- a/app/Data/InfrastructureData.php
+++ b/app/Data/InfrastructureData.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Data;
+
+final readonly class InfrastructureData
+{
+    public function __construct(
+        public string $id,
+        public string $name,
+        public ?string $description,
+        public string $status,
+        public string $cloudProviderId,
+    ) {}
+
+    /**
+     * @param  array{id: string, name: string, description: string|null, status: string, cloud_provider_id: string}  $data
+     */
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            id: $data['id'],
+            name: $data['name'],
+            description: $data['description'] ?? null,
+            status: $data['status'],
+            cloudProviderId: $data['cloud_provider_id'],
+        );
+    }
+
+    /**
+     * @return array{id: string, name: string, description: string|null, status: string, cloud_provider_id: string}
+     */
+    public function toArray(): array
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'description' => $this->description,
+            'status' => $this->status,
+            'cloud_provider_id' => $this->cloudProviderId,
+        ];
+    }
+}

--- a/app/Http/Controllers/Api/V1/InfrastructureController.php
+++ b/app/Http/Controllers/Api/V1/InfrastructureController.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Actions\CreateInfrastructure;
+use App\Data\CreateInfrastructureData;
+use App\Http\Requests\Api\V1\CreateInfrastructureRequest;
+use App\Http\Resources\InfrastructureResource;
+use App\Queries\CloudProviderQuery;
+use App\Queries\InfrastructureQuery;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+
+final class InfrastructureController
+{
+    public function index(Request $request, InfrastructureQuery $infrastructureQuery): AnonymousResourceCollection
+    {
+        $infrastructures = ($infrastructureQuery)()
+            ->byOrganization($request->organization)
+            ->ordered()
+            ->get();
+
+        return InfrastructureResource::collection($infrastructures);
+    }
+
+    public function store(
+        CreateInfrastructureRequest $request,
+        CreateInfrastructure $createInfrastructure,
+        CloudProviderQuery $cloudProviderQuery,
+    ): JsonResponse {
+        $provider = ($cloudProviderQuery)()
+            ->byOrganization($request->organization)
+            ->builder()
+            ->findOrFail($request->validated('cloud_provider_id'));
+
+        $infrastructure = $createInfrastructure->handle(
+            $provider,
+            new CreateInfrastructureData(
+                name: $request->validated('name'),
+                description: $request->validated('description'),
+            ),
+        )->refresh();
+
+        return (new InfrastructureResource($infrastructure))
+            ->response()
+            ->setStatusCode(201);
+    }
+}

--- a/app/Http/Middleware/ResolveInfrastructure.php
+++ b/app/Http/Middleware/ResolveInfrastructure.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware;
+
+use App\Enums\ApiErrorCode;
+use App\Models\Infrastructure;
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+final class ResolveInfrastructure
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        $infrastructureId = $request->header('X-Infrastructure-Id');
+
+        if ($infrastructureId === null) {
+            return response()->json([
+                'message' => 'The X-Infrastructure-Id header is required.',
+                'code' => ApiErrorCode::ValidationFailed->value,
+                'errors' => [],
+            ], ApiErrorCode::ValidationFailed->httpStatus());
+        }
+
+        $infrastructure = Infrastructure::query()->find($infrastructureId);
+
+        if ($infrastructure === null) {
+            return response()->json([
+                'message' => 'Infrastructure not found.',
+                'code' => ApiErrorCode::NotFound->value,
+                'errors' => [],
+            ], ApiErrorCode::NotFound->httpStatus());
+        }
+
+        if ($infrastructure->organization_id !== $request->organization?->id) {
+            return response()->json([
+                'message' => 'Infrastructure does not belong to this organization.',
+                'code' => ApiErrorCode::Forbidden->value,
+                'errors' => [],
+            ], ApiErrorCode::Forbidden->httpStatus());
+        }
+
+        $request->merge(['infrastructure' => $infrastructure]);
+
+        return $next($request);
+    }
+}

--- a/app/Http/Requests/Api/V1/CreateInfrastructureRequest.php
+++ b/app/Http/Requests/Api/V1/CreateInfrastructureRequest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Api\V1;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+final class CreateInfrastructureRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, array<int, string>>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'description' => ['nullable', 'string', 'max:1000'],
+            'cloud_provider_id' => ['required', 'string', 'exists:cloud_providers,id'],
+        ];
+    }
+}

--- a/app/Http/Resources/InfrastructureResource.php
+++ b/app/Http/Resources/InfrastructureResource.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources;
+
+use App\Models\Infrastructure;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin Infrastructure
+ */
+final class InfrastructureResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'description' => $this->description,
+            'status' => $this->status->value,
+            'cloud_provider_id' => $this->cloud_provider_id,
+        ];
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -6,11 +6,13 @@ namespace App\Providers;
 
 use App\Client\HttpAuthClient;
 use App\Client\HttpCloudProviderClient;
+use App\Client\HttpInfrastructureClient;
 use App\Client\HttpOrganizationClient;
 use App\Client\LarakubeClient;
 use App\Console\Services\SessionManager;
 use App\Contracts\AuthClient;
 use App\Contracts\CloudProviderClient;
+use App\Contracts\InfrastructureClient;
 use App\Contracts\OrganizationClient;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Database\Eloquent\Model;
@@ -48,6 +50,7 @@ final class AppServiceProvider extends ServiceProvider
         $this->app->bind(AuthClient::class, HttpAuthClient::class);
         $this->app->bind(OrganizationClient::class, HttpOrganizationClient::class);
         $this->app->bind(CloudProviderClient::class, HttpCloudProviderClient::class);
+        $this->app->bind(InfrastructureClient::class, HttpInfrastructureClient::class);
     }
 
     /**

--- a/routes/api.php
+++ b/routes/api.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use App\Http\Controllers\Api\V1\AuthTokenController;
 use App\Http\Controllers\Api\V1\CloudProviderController;
+use App\Http\Controllers\Api\V1\InfrastructureController;
 use App\Http\Controllers\Api\V1\OrganizationController;
 use App\Http\Controllers\Api\V1\RegisterController;
 use App\Http\Middleware\ResolveOrganization;
@@ -28,6 +29,10 @@ Route::prefix('v1')->as('api.v1.')->group(function (): void {
             Route::apiResource('cloud-providers', CloudProviderController::class)
                 ->only(['index', 'store', 'destroy'])
                 ->names('cloud-providers');
+
+            Route::apiResource('infrastructures', InfrastructureController::class)
+                ->only(['index', 'store'])
+                ->names('infrastructures');
         });
     });
 });

--- a/tests/Feature/Api/V1/InfrastructureControllerTest.php
+++ b/tests/Feature/Api/V1/InfrastructureControllerTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\CloudProvider;
+use App\Models\Infrastructure;
+use App\Models\Organization;
+use App\Models\User;
+
+beforeEach(function (): void {
+    /** @var User $user */
+    $this->user = User::factory()->create();
+    $this->organization = Organization::factory()->create();
+    $this->user->organizations()->attach($this->organization, ['role' => 'owner']);
+    $this->provider = CloudProvider::factory()->hetzner()->create([
+        'organization_id' => $this->organization->id,
+    ]);
+});
+
+test('store creates an infrastructure and returns data',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        $response = $this->actingAs($this->user, 'sanctum')
+            ->withHeaders(['X-Organization-Id' => $this->organization->id])
+            ->postJson(route('api.v1.infrastructures.store'), [
+                'name' => 'Production',
+                'description' => 'Production infrastructure',
+                'cloud_provider_id' => $this->provider->id,
+            ]);
+
+        $response->assertCreated()
+            ->assertJsonStructure([
+                'data' => ['id', 'name', 'description', 'status', 'cloud_provider_id'],
+            ])
+            ->assertJsonPath('data.name', 'Production')
+            ->assertJsonPath('data.cloud_provider_id', $this->provider->id);
+
+        $this->assertDatabaseHas('infrastructures', [
+            'name' => 'Production',
+            'cloud_provider_id' => $this->provider->id,
+            'organization_id' => $this->organization->id,
+        ]);
+    });
+
+test('store validates required fields',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        $response = $this->actingAs($this->user, 'sanctum')
+            ->withHeaders(['X-Organization-Id' => $this->organization->id])
+            ->postJson(route('api.v1.infrastructures.store'), []);
+
+        $response->assertUnprocessable()
+            ->assertJsonValidationErrors(['name', 'cloud_provider_id']);
+    });
+
+test('index returns infrastructures for organization',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        Infrastructure::factory()->create([
+            'organization_id' => $this->organization->id,
+            'cloud_provider_id' => $this->provider->id,
+            'name' => 'Production',
+        ]);
+
+        $otherOrg = Organization::factory()->create();
+        Infrastructure::factory()->create([
+            'organization_id' => $otherOrg->id,
+            'name' => 'Other Infra',
+        ]);
+
+        $response = $this->actingAs($this->user, 'sanctum')
+            ->withHeaders(['X-Organization-Id' => $this->organization->id])
+            ->getJson(route('api.v1.infrastructures.index'));
+
+        $response->assertOk()
+            ->assertJsonCount(1, 'data')
+            ->assertJsonPath('data.0.name', 'Production');
+    });
+
+test('all endpoints require authentication',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        $this->postJson(route('api.v1.infrastructures.store'))->assertUnauthorized();
+        $this->getJson(route('api.v1.infrastructures.index'))->assertUnauthorized();
+    });
+
+test('all endpoints require organization header',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        $this->actingAs($this->user, 'sanctum')
+            ->postJson(route('api.v1.infrastructures.store'))
+            ->assertUnprocessable();
+
+        $this->actingAs($this->user, 'sanctum')
+            ->getJson(route('api.v1.infrastructures.index'))
+            ->assertUnprocessable();
+    });

--- a/tests/Feature/Commands/CreateInfrastructureCommandTest.php
+++ b/tests/Feature/Commands/CreateInfrastructureCommandTest.php
@@ -3,14 +3,23 @@
 declare(strict_types=1);
 
 use App\Actions\LoginUser;
+use App\Client\InMemoryCloudProviderClient;
+use App\Client\InMemoryInfrastructureClient;
 use App\Console\Services\SessionManager;
+use App\Contracts\CloudProviderClient;
+use App\Contracts\InfrastructureClient;
+use App\Data\CloudProviderData;
+use App\Data\InfrastructureData;
 use App\Data\SessionOrganizationData;
-use App\Models\CloudProvider;
 use App\Models\Organization;
 use App\Models\User;
 
 beforeEach(function (): void {
     $this->app->singleton(SessionManager::class);
+    $this->cloudProviderClient = new InMemoryCloudProviderClient();
+    $this->app->instance(CloudProviderClient::class, $this->cloudProviderClient);
+    $this->infrastructureClient = new InMemoryInfrastructureClient();
+    $this->app->instance(InfrastructureClient::class, $this->infrastructureClient);
 });
 
 test('create infrastructure command creates infrastructure successfully',
@@ -18,18 +27,15 @@ test('create infrastructure command creates infrastructure successfully',
      * @throws Throwable
      */
     function (): void {
+        /** @var User $user */
         $user = User::factory()->create([
             'email' => 'john@example.com',
             'password' => 'password123',
         ]);
 
+        /** @var Organization $organization */
         $organization = Organization::factory()->create();
         $organization->users()->attach($user, ['role' => 'owner']);
-
-        $provider = CloudProvider::factory()->hetzner()->create([
-            'organization_id' => $organization->id,
-            'name' => 'Hetzner Prod',
-        ]);
 
         $userData = app(LoginUser::class)->handle('john@example.com', 'password123');
         $session = app(SessionManager::class);
@@ -40,18 +46,24 @@ test('create infrastructure command creates infrastructure successfully',
             slug: $organization->slug,
         ));
 
+        $this->cloudProviderClient->setListResponse([
+            new CloudProviderData(id: 'cp-1', name: 'Hetzner Prod', type: 'hetzner', isVerified: true),
+        ]);
+
+        $this->infrastructureClient->setCreateResponse(new InfrastructureData(
+            id: 'infra-1',
+            name: 'Production',
+            description: 'Production infrastructure',
+            status: 'healthy',
+            cloudProviderId: 'cp-1',
+        ));
+
         $this->artisan('infrastructure:create')
-            ->expectsQuestion('Select a cloud provider', $provider->id)
+            ->expectsQuestion('Select a cloud provider', 'cp-1')
             ->expectsQuestion('Infrastructure name', 'Production')
             ->expectsQuestion('Description (optional)', 'Production infrastructure')
             ->expectsOutputToContain('Infrastructure [Production] created successfully')
             ->assertSuccessful();
-
-        $this->assertDatabaseHas('infrastructures', [
-            'name' => 'Production',
-            'description' => 'Production infrastructure',
-            'cloud_provider_id' => $provider->id,
-        ]);
     });
 
 test('create infrastructure command fails when not authenticated',
@@ -69,11 +81,13 @@ test('create infrastructure command shows message when no providers',
      * @throws Throwable
      */
     function (): void {
+        /** @var User $user */
         $user = User::factory()->create([
             'email' => 'john@example.com',
             'password' => 'password123',
         ]);
 
+        /** @var Organization $organization */
         $organization = Organization::factory()->create();
         $organization->users()->attach($user, ['role' => 'owner']);
 
@@ -91,23 +105,20 @@ test('create infrastructure command shows message when no providers',
             ->assertSuccessful();
     });
 
-test('create infrastructure command fails when provider not found from CLI option',
+test('create infrastructure command displays error on list providers failure',
     /**
      * @throws Throwable
      */
     function (): void {
+        /** @var User $user */
         $user = User::factory()->create([
             'email' => 'john@example.com',
             'password' => 'password123',
         ]);
 
+        /** @var Organization $organization */
         $organization = Organization::factory()->create();
         $organization->users()->attach($user, ['role' => 'owner']);
-
-        $provider = CloudProvider::factory()->hetzner()->create([
-            'organization_id' => $organization->id,
-            'name' => 'Hetzner Prod',
-        ]);
 
         $userData = app(LoginUser::class)->handle('john@example.com', 'password123');
         $session = app(SessionManager::class);
@@ -117,6 +128,112 @@ test('create infrastructure command fails when provider not found from CLI optio
             name: $organization->name,
             slug: $organization->slug,
         ));
+
+        $this->cloudProviderClient->shouldFailList();
+
+        $this->artisan('infrastructure:create')
+            ->expectsOutputToContain('Unauthenticated.')
+            ->assertFailed();
+    });
+
+test('create infrastructure command displays error on create failure',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var User $user */
+        $user = User::factory()->create([
+            'email' => 'john@example.com',
+            'password' => 'password123',
+        ]);
+
+        /** @var Organization $organization */
+        $organization = Organization::factory()->create();
+        $organization->users()->attach($user, ['role' => 'owner']);
+
+        $userData = app(LoginUser::class)->handle('john@example.com', 'password123');
+        $session = app(SessionManager::class);
+        $session->setUser($userData);
+        $session->setOrganization(new SessionOrganizationData(
+            id: $organization->id,
+            name: $organization->name,
+            slug: $organization->slug,
+        ));
+
+        $this->cloudProviderClient->setListResponse([
+            new CloudProviderData(id: 'cp-1', name: 'Hetzner Prod', type: 'hetzner', isVerified: true),
+        ]);
+
+        $this->infrastructureClient->shouldFailCreate();
+
+        $this->artisan('infrastructure:create')
+            ->expectsQuestion('Select a cloud provider', 'cp-1')
+            ->expectsQuestion('Infrastructure name', 'Production')
+            ->expectsQuestion('Description (optional)', '')
+            ->expectsOutputToContain('Validation failed.')
+            ->assertFailed();
+    });
+
+test('create infrastructure command works with provider CLI option',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var User $user */
+        $user = User::factory()->create([
+            'email' => 'john@example.com',
+            'password' => 'password123',
+        ]);
+
+        /** @var Organization $organization */
+        $organization = Organization::factory()->create();
+        $organization->users()->attach($user, ['role' => 'owner']);
+
+        $userData = app(LoginUser::class)->handle('john@example.com', 'password123');
+        $session = app(SessionManager::class);
+        $session->setUser($userData);
+        $session->setOrganization(new SessionOrganizationData(
+            id: $organization->id,
+            name: $organization->name,
+            slug: $organization->slug,
+        ));
+
+        $this->cloudProviderClient->setListResponse([
+            new CloudProviderData(id: 'cp-1', name: 'Hetzner Prod', type: 'hetzner', isVerified: true),
+        ]);
+
+        $this->artisan('infrastructure:create --provider=cp-1 --name="Staging" --description="Staging infra"')
+            ->expectsOutputToContain('Infrastructure [Staging] created successfully')
+            ->assertSuccessful();
+    });
+
+test('create infrastructure command fails when provider not found from CLI option',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var User $user */
+        $user = User::factory()->create([
+            'email' => 'john@example.com',
+            'password' => 'password123',
+        ]);
+
+        /** @var Organization $organization */
+        $organization = Organization::factory()->create();
+        $organization->users()->attach($user, ['role' => 'owner']);
+
+        $userData = app(LoginUser::class)->handle('john@example.com', 'password123');
+        $session = app(SessionManager::class);
+        $session->setUser($userData);
+        $session->setOrganization(new SessionOrganizationData(
+            id: $organization->id,
+            name: $organization->name,
+            slug: $organization->slug,
+        ));
+
+        $this->cloudProviderClient->setListResponse([
+            new CloudProviderData(id: 'cp-1', name: 'Hetzner Prod', type: 'hetzner', isVerified: true),
+        ]);
 
         $this->artisan('infrastructure:create --provider=99999 --name="Test"')
             ->expectsOutputToContain('Provider not found.')

--- a/tests/Feature/Commands/SelectInfrastructureCommandTest.php
+++ b/tests/Feature/Commands/SelectInfrastructureCommandTest.php
@@ -3,15 +3,23 @@
 declare(strict_types=1);
 
 use App\Actions\LoginUser;
+use App\Client\InMemoryCloudProviderClient;
+use App\Client\InMemoryInfrastructureClient;
 use App\Console\Services\SessionManager;
+use App\Contracts\CloudProviderClient;
+use App\Contracts\InfrastructureClient;
+use App\Data\CloudProviderData;
+use App\Data\InfrastructureData;
 use App\Data\SessionOrganizationData;
-use App\Models\CloudProvider;
-use App\Models\Infrastructure;
 use App\Models\Organization;
 use App\Models\User;
 
 beforeEach(function (): void {
     $this->app->singleton(SessionManager::class);
+    $this->cloudProviderClient = new InMemoryCloudProviderClient();
+    $this->app->instance(CloudProviderClient::class, $this->cloudProviderClient);
+    $this->infrastructureClient = new InMemoryInfrastructureClient();
+    $this->app->instance(InfrastructureClient::class, $this->infrastructureClient);
 });
 
 test('select infrastructure command selects infrastructure successfully',
@@ -19,24 +27,15 @@ test('select infrastructure command selects infrastructure successfully',
      * @throws Throwable
      */
     function (): void {
+        /** @var User $user */
         $user = User::factory()->create([
             'email' => 'john@example.com',
             'password' => 'password123',
         ]);
 
+        /** @var Organization $organization */
         $organization = Organization::factory()->create();
         $organization->users()->attach($user, ['role' => 'owner']);
-
-        $provider = CloudProvider::factory()->hetzner()->create([
-            'organization_id' => $organization->id,
-            'name' => 'Hetzner Prod',
-        ]);
-
-        $infrastructure = Infrastructure::factory()->create([
-            'organization_id' => $organization->id,
-            'cloud_provider_id' => $provider->id,
-            'name' => 'Production',
-        ]);
 
         $userData = app(LoginUser::class)->handle('john@example.com', 'password123');
         $session = app(SessionManager::class);
@@ -47,14 +46,88 @@ test('select infrastructure command selects infrastructure successfully',
             slug: $organization->slug,
         ));
 
+        $this->cloudProviderClient->setListResponse([
+            new CloudProviderData(id: 'cp-1', name: 'Hetzner Prod', type: 'hetzner', isVerified: true),
+        ]);
+
+        $this->infrastructureClient->setListResponse([
+            new InfrastructureData(id: 'infra-1', name: 'Production', description: null, status: 'healthy', cloudProviderId: 'cp-1'),
+        ]);
+
         $this->artisan('infrastructure:select')
-            ->expectsQuestion('Select a cloud provider', $provider->id)
-            ->expectsQuestion('Select an infrastructure', $infrastructure->id)
+            ->expectsQuestion('Select a cloud provider', 'cp-1')
+            ->expectsQuestion('Select an infrastructure', 'infra-1')
             ->expectsOutputToContain('Selected infrastructure [Production]')
             ->assertSuccessful();
 
         expect($session->getInfrastructure())->not->toBeNull()
-            ->and($session->getInfrastructure()?->id)->toBe($infrastructure->id);
+            ->and($session->getInfrastructure()?->id)->toBe('infra-1');
+    });
+
+test('select infrastructure command displays error on list providers failure',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var User $user */
+        $user = User::factory()->create([
+            'email' => 'john@example.com',
+            'password' => 'password123',
+        ]);
+
+        /** @var Organization $organization */
+        $organization = Organization::factory()->create();
+        $organization->users()->attach($user, ['role' => 'owner']);
+
+        $userData = app(LoginUser::class)->handle('john@example.com', 'password123');
+        $session = app(SessionManager::class);
+        $session->setUser($userData);
+        $session->setOrganization(new SessionOrganizationData(
+            id: $organization->id,
+            name: $organization->name,
+            slug: $organization->slug,
+        ));
+
+        $this->cloudProviderClient->shouldFailList();
+
+        $this->artisan('infrastructure:select')
+            ->expectsOutputToContain('Unauthenticated.')
+            ->assertFailed();
+    });
+
+test('select infrastructure command displays error on list infra failure',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var User $user */
+        $user = User::factory()->create([
+            'email' => 'john@example.com',
+            'password' => 'password123',
+        ]);
+
+        /** @var Organization $organization */
+        $organization = Organization::factory()->create();
+        $organization->users()->attach($user, ['role' => 'owner']);
+
+        $userData = app(LoginUser::class)->handle('john@example.com', 'password123');
+        $session = app(SessionManager::class);
+        $session->setUser($userData);
+        $session->setOrganization(new SessionOrganizationData(
+            id: $organization->id,
+            name: $organization->name,
+            slug: $organization->slug,
+        ));
+
+        $this->cloudProviderClient->setListResponse([
+            new CloudProviderData(id: 'cp-1', name: 'Hetzner Prod', type: 'hetzner', isVerified: true),
+        ]);
+        $this->infrastructureClient->shouldFailList();
+
+        $this->artisan('infrastructure:select')
+            ->expectsQuestion('Select a cloud provider', 'cp-1')
+            ->expectsOutputToContain('Unauthenticated.')
+            ->assertFailed();
     });
 
 test('select infrastructure command fails when no providers',
@@ -62,11 +135,13 @@ test('select infrastructure command fails when no providers',
      * @throws Throwable
      */
     function (): void {
+        /** @var User $user */
         $user = User::factory()->create([
             'email' => 'john@example.com',
             'password' => 'password123',
         ]);
 
+        /** @var Organization $organization */
         $organization = Organization::factory()->create();
         $organization->users()->attach($user, ['role' => 'owner']);
 
@@ -89,18 +164,15 @@ test('select infrastructure command fails when no infrastructures',
      * @throws Throwable
      */
     function (): void {
+        /** @var User $user */
         $user = User::factory()->create([
             'email' => 'john@example.com',
             'password' => 'password123',
         ]);
 
+        /** @var Organization $organization */
         $organization = Organization::factory()->create();
         $organization->users()->attach($user, ['role' => 'owner']);
-
-        $provider = CloudProvider::factory()->hetzner()->create([
-            'organization_id' => $organization->id,
-            'name' => 'Hetzner Prod',
-        ]);
 
         $userData = app(LoginUser::class)->handle('john@example.com', 'password123');
         $session = app(SessionManager::class);
@@ -111,8 +183,12 @@ test('select infrastructure command fails when no infrastructures',
             slug: $organization->slug,
         ));
 
+        $this->cloudProviderClient->setListResponse([
+            new CloudProviderData(id: 'cp-1', name: 'Hetzner Prod', type: 'hetzner', isVerified: true),
+        ]);
+
         $this->artisan('infrastructure:select')
-            ->expectsQuestion('Select a cloud provider', $provider->id)
+            ->expectsQuestion('Select a cloud provider', 'cp-1')
             ->expectsOutputToContain('No infrastructures configured')
             ->assertFailed();
     });
@@ -132,6 +208,7 @@ test('select infrastructure command fails when no organization selected',
      * @throws Throwable
      */
     function (): void {
+        /** @var User $user */
         $user = User::factory()->create([
             'email' => 'john@example.com',
             'password' => 'password123',

--- a/tests/Feature/Middleware/ResolveInfrastructureTest.php
+++ b/tests/Feature/Middleware/ResolveInfrastructureTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Http\Middleware\ResolveInfrastructure;
+use App\Http\Middleware\ResolveOrganization;
+use App\Models\Infrastructure;
+use App\Models\Organization;
+use App\Models\User;
+use Illuminate\Support\Facades\Route;
+
+beforeEach(function (): void {
+    Route::middleware(['auth:sanctum', ResolveOrganization::class, ResolveInfrastructure::class])
+        ->get('/test/infra-middleware', fn () => response()->json(['ok' => true]));
+});
+
+test('resolves infrastructure from header',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var User $user */
+        $user = User::factory()->create();
+        $org = Organization::factory()->create();
+        $user->organizations()->attach($org, ['role' => 'member']);
+        $infra = Infrastructure::factory()->create(['organization_id' => $org->id]);
+
+        $response = $this->actingAs($user, 'sanctum')
+            ->withHeaders([
+                'X-Organization-Id' => $org->id,
+                'X-Infrastructure-Id' => $infra->id,
+            ])
+            ->getJson('/test/infra-middleware');
+
+        $response->assertOk();
+    });
+
+test('returns 422 when header is missing',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var User $user */
+        $user = User::factory()->create();
+        $org = Organization::factory()->create();
+        $user->organizations()->attach($org, ['role' => 'member']);
+
+        $response = $this->actingAs($user, 'sanctum')
+            ->withHeaders(['X-Organization-Id' => $org->id])
+            ->getJson('/test/infra-middleware');
+
+        $response->assertUnprocessable()
+            ->assertJsonPath('code', 'validation_failed');
+    });
+
+test('returns 404 when infrastructure does not exist',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var User $user */
+        $user = User::factory()->create();
+        $org = Organization::factory()->create();
+        $user->organizations()->attach($org, ['role' => 'member']);
+
+        $response = $this->actingAs($user, 'sanctum')
+            ->withHeaders([
+                'X-Organization-Id' => $org->id,
+                'X-Infrastructure-Id' => 'non-existent',
+            ])
+            ->getJson('/test/infra-middleware');
+
+        $response->assertNotFound()
+            ->assertJsonPath('code', 'not_found');
+    });
+
+test('returns 403 when infrastructure belongs to another organization',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var User $user */
+        $user = User::factory()->create();
+        $org = Organization::factory()->create();
+        $user->organizations()->attach($org, ['role' => 'member']);
+        $otherOrg = Organization::factory()->create();
+        $infra = Infrastructure::factory()->create(['organization_id' => $otherOrg->id]);
+
+        $response = $this->actingAs($user, 'sanctum')
+            ->withHeaders([
+                'X-Organization-Id' => $org->id,
+                'X-Infrastructure-Id' => $infra->id,
+            ])
+            ->getJson('/test/infra-middleware');
+
+        $response->assertForbidden()
+            ->assertJsonPath('code', 'forbidden');
+    });

--- a/tests/Unit/Client/HttpInfrastructureClientTest.php
+++ b/tests/Unit/Client/HttpInfrastructureClientTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Client\HttpInfrastructureClient;
+use App\Client\LarakubeClient;
+use App\Data\CreateInfrastructureData;
+use App\Data\InfrastructureData;
+use Illuminate\Support\Facades\Http;
+
+beforeEach(function (): void {
+    $this->client = new HttpInfrastructureClient(
+        new LarakubeClient(baseUrl: 'http://localhost:8000', token: '1|abc', organizationId: 'org-1'),
+    );
+});
+
+test('create returns infrastructure data',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        Http::fake([
+            '*/api/v1/infrastructures' => Http::response([
+                'data' => [
+                    'id' => 'uuid-1',
+                    'name' => 'Production',
+                    'description' => 'Prod infra',
+                    'status' => 'healthy',
+                    'cloud_provider_id' => 'cp-1',
+                ],
+            ], 201),
+        ]);
+
+        $result = $this->client->create(
+            new CreateInfrastructureData(name: 'Production', description: 'Prod infra'),
+            'cp-1',
+        );
+
+        expect($result)
+            ->toBeInstanceOf(InfrastructureData::class)
+            ->name->toBe('Production')
+            ->cloudProviderId->toBe('cp-1');
+    });
+
+test('list returns array of infrastructure data',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        Http::fake([
+            '*/api/v1/infrastructures' => Http::response([
+                'data' => [
+                    ['id' => 'uuid-1', 'name' => 'Prod', 'description' => null, 'status' => 'healthy', 'cloud_provider_id' => 'cp-1'],
+                ],
+            ]),
+        ]);
+
+        $result = $this->client->list();
+
+        expect($result)->toHaveCount(1)
+            ->and($result[0]->name)->toBe('Prod');
+    });

--- a/tests/Unit/Client/InMemoryInfrastructureClientTest.php
+++ b/tests/Unit/Client/InMemoryInfrastructureClientTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Client\InMemoryInfrastructureClient;
+use App\Data\CreateInfrastructureData;
+use App\Data\InfrastructureData;
+use App\Exceptions\LarakubeApiException;
+
+beforeEach(function (): void {
+    $this->client = new InMemoryInfrastructureClient();
+});
+
+test('create returns configured data',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        $data = new InfrastructureData(id: 'uuid-1', name: 'Prod', description: null, status: 'healthy', cloudProviderId: 'cp-1');
+        $this->client->setCreateResponse($data);
+
+        $result = $this->client->create(new CreateInfrastructureData(name: 'Prod'), 'cp-1');
+
+        expect($result)->toBe($data);
+    });
+
+test('create throws when configured to fail',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        $this->client->shouldFailCreate();
+
+        $this->client->create(new CreateInfrastructureData(name: 'Prod'), 'cp-1');
+    })->throws(LarakubeApiException::class);
+
+test('list returns configured data',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        $infras = [
+            new InfrastructureData(id: 'uuid-1', name: 'Prod', description: null, status: 'healthy', cloudProviderId: 'cp-1'),
+        ];
+        $this->client->setListResponse($infras);
+
+        expect($this->client->list())->toBe($infras);
+    });
+
+test('list returns empty by default',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        expect($this->client->list())->toBe([]);
+    });
+
+test('list throws when configured to fail',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        $this->client->shouldFailList();
+
+        $this->client->list();
+    })->throws(LarakubeApiException::class);

--- a/tests/Unit/Data/InfrastructureDataTest.php
+++ b/tests/Unit/Data/InfrastructureDataTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Data\InfrastructureData;
+
+test('constructor sets properties', function (): void {
+    $data = new InfrastructureData(
+        id: 'uuid-1',
+        name: 'Production',
+        description: 'Prod infra',
+        status: 'healthy',
+        cloudProviderId: 'cp-1',
+    );
+
+    expect($data)
+        ->id->toBe('uuid-1')
+        ->name->toBe('Production')
+        ->description->toBe('Prod infra')
+        ->status->toBe('healthy')
+        ->cloudProviderId->toBe('cp-1');
+});
+
+test('fromArray and toArray round-trip', function (): void {
+    $original = [
+        'id' => 'uuid-1',
+        'name' => 'Production',
+        'description' => 'Prod infra',
+        'status' => 'healthy',
+        'cloud_provider_id' => 'cp-1',
+    ];
+
+    $data = InfrastructureData::fromArray($original);
+
+    expect($data->toArray())->toBe($original);
+});


### PR DESCRIPTION
## Summary

- Adds `POST /api/v1/infrastructures` and `GET /api/v1/infrastructures` endpoints with `InfrastructureController`
- All endpoints require `auth:sanctum` + `ResolveOrganization` middleware
- Introduces `ResolveInfrastructure` middleware for `X-Infrastructure-Id` header resolution (validates existence and org ownership)
- Introduces `InfrastructureClient` contract with `HttpInfrastructureClient` and `InMemoryInfrastructureClient` implementations
- Adds `InfrastructureData` response DTO and `InfrastructureResource` JSON resource
- Rewires `infrastructure:create` and `infrastructure:select` commands to use client layer
- Uses `CloudProviderQuery` (CQRS) in controller instead of direct model queries

Closes #6

## Test plan

- [x] 423 tests passing (897 assertions)
- [x] 100% code coverage
- [x] 100% type coverage
- [x] Pint clean
- [x] API endpoint tests for infrastructure create and list
- [x] Middleware tests for ResolveInfrastructure (missing header, not found, wrong org, success)
- [x] HTTP client tests with `Http::fake()`
- [x] InMemory client tests for controllable test doubles
- [x] Command tests using InMemory clients (all paths including error branches)
- [x] InfrastructureData DTO round-trip tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)