### PR TITLE
fix: Cloud provider API error handling

### DIFF
--- a/app/Services/DigitalOceanServerService.php
+++ b/app/Services/DigitalOceanServerService.php
@@ -11,6 +11,7 @@ use App\Enums\ServerStatus;
 use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Http;
+use RuntimeException;
 
 final readonly class DigitalOceanServerService implements ServerService
 {
@@ -18,11 +19,16 @@ final readonly class DigitalOceanServerService implements ServerService
 
     /**
      * @throws ConnectionException
+     * @throws RuntimeException
      */
     public function getAll(): Collection
     {
         $response = Http::withToken($this->token)
             ->get('https://api.digitalocean.com/v2/droplets');
+
+        if (! $response->successful()) {
+            throw new RuntimeException($response->json('message', 'Failed to fetch droplets from DigitalOcean.'));
+        }
 
         return collect($response->json('droplets', []))
             ->map($this->mapServerData(...));
@@ -30,6 +36,7 @@ final readonly class DigitalOceanServerService implements ServerService
 
     /**
      * @throws ConnectionException
+     * @throws RuntimeException
      */
     public function create(CreateServerData $data): ServerData
     {
@@ -41,16 +48,25 @@ final readonly class DigitalOceanServerService implements ServerService
                 'region' => $data->region,
             ]);
 
+        if (! $response->successful()) {
+            throw new RuntimeException($response->json('message', 'Failed to create droplet on DigitalOcean.'));
+        }
+
         return $this->mapServerData($response->json('droplet'));
     }
 
     /**
      * @throws ConnectionException
+     * @throws RuntimeException
      */
     public function find(string $name): ?ServerData
     {
         $response = Http::withToken($this->token)
             ->get('https://api.digitalocean.com/v2/droplets', ['name' => $name]);
+
+        if (! $response->successful()) {
+            throw new RuntimeException($response->json('message', 'Failed to search droplets on DigitalOcean.'));
+        }
 
         $droplets = $response->json('droplets', []);
 

--- a/app/Services/HetznerServerService.php
+++ b/app/Services/HetznerServerService.php
@@ -11,6 +11,7 @@ use App\Enums\ServerStatus;
 use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Http;
+use RuntimeException;
 
 final readonly class HetznerServerService implements ServerService
 {
@@ -18,11 +19,16 @@ final readonly class HetznerServerService implements ServerService
 
     /**
      * @throws ConnectionException
+     * @throws RuntimeException
      */
     public function getAll(): Collection
     {
         $response = Http::withToken($this->token)
             ->get('https://api.hetzner.cloud/v1/servers');
+
+        if (! $response->successful()) {
+            throw new RuntimeException($response->json('error.message', 'Failed to fetch servers from Hetzner.'));
+        }
 
         return collect($response->json('servers', []))
             ->map($this->mapServerData(...));
@@ -30,6 +36,7 @@ final readonly class HetznerServerService implements ServerService
 
     /**
      * @throws ConnectionException
+     * @throws RuntimeException
      */
     public function create(CreateServerData $data): ServerData
     {
@@ -41,16 +48,25 @@ final readonly class HetznerServerService implements ServerService
                 'location' => $data->region,
             ]);
 
+        if (! $response->successful()) {
+            throw new RuntimeException($response->json('error.message', 'Failed to create server on Hetzner.'));
+        }
+
         return $this->mapServerData($response->json('server'));
     }
 
     /**
      * @throws ConnectionException
+     * @throws RuntimeException
      */
     public function find(string $name): ?ServerData
     {
         $response = Http::withToken($this->token)
             ->get('https://api.hetzner.cloud/v1/servers', ['name' => $name]);
+
+        if (! $response->successful()) {
+            throw new RuntimeException($response->json('error.message', 'Failed to search servers on Hetzner.'));
+        }
 
         $servers = $response->json('servers', []);
 

--- a/tests/Unit/Services/DigitalOceanServerServiceTest.php
+++ b/tests/Unit/Services/DigitalOceanServerServiceTest.php
@@ -69,6 +69,38 @@ test('create returns server data', function (): void {
         ->and($server->ipv4)->toBeNull();
 });
 
+test('create throws on api error', function (): void {
+    Http::fake([
+        'api.digitalocean.com/v2/droplets' => Http::response([
+            'id' => 'bad_request',
+            'message' => 'Name is required',
+        ], 422),
+    ]);
+
+    $service = new DigitalOceanServerService('token');
+
+    $service->create(new CreateServerData(
+        name: '',
+        type: 's-1vcpu-1gb',
+        image: 'ubuntu-22.04',
+        region: 'nyc1',
+        infrastructure_id: '00000000-0000-0000-0000-000000000001',
+    ));
+})->throws(RuntimeException::class, 'Name is required');
+
+test('get all throws on api error', function (): void {
+    Http::fake([
+        'api.digitalocean.com/v2/droplets' => Http::response([
+            'id' => 'unauthorized',
+            'message' => 'Unable to authenticate you',
+        ], 401),
+    ]);
+
+    $service = new DigitalOceanServerService('token');
+
+    $service->getAll();
+})->throws(RuntimeException::class, 'Unable to authenticate you');
+
 test('find returns server data', function (): void {
     Http::fake([
         'api.digitalocean.com/v2/droplets*' => Http::response([
@@ -91,6 +123,19 @@ test('find returns server data', function (): void {
     expect($server)->not->toBeNull()
         ->and($server->name)->toBe('web-1');
 });
+
+test('find throws on api error', function (): void {
+    Http::fake([
+        'api.digitalocean.com/v2/droplets*' => Http::response([
+            'id' => 'forbidden',
+            'message' => 'You do not have access for the attempted action.',
+        ], 403),
+    ]);
+
+    $service = new DigitalOceanServerService('token');
+
+    $service->find('web-1');
+})->throws(RuntimeException::class, 'You do not have access for the attempted action.');
 
 test('find returns null when not found', function (): void {
     Http::fake([

--- a/tests/Unit/Services/HetznerServerServiceTest.php
+++ b/tests/Unit/Services/HetznerServerServiceTest.php
@@ -70,6 +70,39 @@ test('create returns server data', function (): void {
         ->and($server->status)->toBe(ServerStatus::Starting);
 });
 
+test('create throws on api error', function (): void {
+    Http::fake([
+        'api.hetzner.cloud/v1/servers' => Http::response([
+            'error' => [
+                'message' => 'server type 104 is deprecated',
+                'code' => 'invalid_input',
+            ],
+        ], 422),
+    ]);
+
+    $service = new HetznerServerService('token');
+
+    $service->create(new CreateServerData(
+        name: 'web-1',
+        type: 'cx22',
+        image: 'ubuntu-22.04',
+        region: 'fsn1',
+        infrastructure_id: '00000000-0000-0000-0000-000000000001',
+    ));
+})->throws(RuntimeException::class, 'server type 104 is deprecated');
+
+test('get all throws on api error', function (): void {
+    Http::fake([
+        'api.hetzner.cloud/v1/servers' => Http::response([
+            'error' => ['message' => 'unauthorized', 'code' => 'unauthorized'],
+        ], 401),
+    ]);
+
+    $service = new HetznerServerService('token');
+
+    $service->getAll();
+})->throws(RuntimeException::class, 'unauthorized');
+
 test('find returns server data', function (): void {
     Http::fake([
         'api.hetzner.cloud/v1/servers*' => Http::response([
@@ -92,6 +125,18 @@ test('find returns server data', function (): void {
     expect($server)->not->toBeNull()
         ->and($server->name)->toBe('web-1');
 });
+
+test('find throws on api error', function (): void {
+    Http::fake([
+        'api.hetzner.cloud/v1/servers*' => Http::response([
+            'error' => ['message' => 'forbidden', 'code' => 'forbidden'],
+        ], 403),
+    ]);
+
+    $service = new HetznerServerService('token');
+
+    $service->find('web-1');
+})->throws(RuntimeException::class, 'forbidden');
 
 test('find returns null when not found', function (): void {
     Http::fake([


### PR DESCRIPTION
## Summary

- `HetznerServerService` and `DigitalOceanServerService` now check `$response->successful()` before accessing response data
- `create()`, `getAll()`, and `find()` throw `RuntimeException` with the provider's error message on API failures
- Previously, API errors caused a `TypeError` because `null` was passed to `mapServerData()` when the expected response key (`server`/`droplet`/`servers`/`droplets`) was missing from error responses

Closes #18

## Test plan

- [x] 453 tests passing (961 assertions)
- [x] 100% code coverage
- [x] Pint clean
- [x] Added error response tests for `create()`, `getAll()`, and `find()` on both Hetzner and DigitalOcean services

🤖 Generated with [Claude Code](https://claude.com/claude-code)