### PR TITLE
Align infrastructure child model tests with CONTRIBUTING.md

### DIFF
--- a/tests/Unit/Models/BackupTest.php
+++ b/tests/Unit/Models/BackupTest.php
@@ -5,39 +5,87 @@ declare(strict_types=1);
 use App\Enums\InfrastructureStatus;
 use App\Models\Backup;
 use App\Models\Infrastructure;
+use Carbon\CarbonImmutable;
 
-test('to array', function (): void {
-
-    /** @var Backup $backup */
-    $backup = Backup::factory()
-        ->create()
-        ->fresh();
-
-    expect(array_keys($backup->toArray()))
-        ->toBe([
-            'id',
-            'created_at',
-            'updated_at',
-            'infrastructure_id',
-            'name',
-            'external_backup_id',
-            'status',
+test('creates backup',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var Backup $backup */
+        $backup = Backup::factory()->create([
+            'name' => 'daily-backup',
         ]);
-});
 
-test('status is cast to enum', function (): void {
-    /** @var Backup $backup */
-    $backup = Backup::factory()->create([
-        'status' => InfrastructureStatus::Healthy,
-    ]);
+        expect($backup->name)->toBe('daily-backup')
+            ->and($backup->id)->toBeString()
+            ->and($backup->created_at)->toBeInstanceOf(CarbonImmutable::class);
+    });
 
-    expect($backup->status)->toBe(InfrastructureStatus::Healthy);
-});
+test('belongs to infrastructure',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var Infrastructure $infrastructure */
+        $infrastructure = Infrastructure::factory()->create();
 
-test('belongs to infrastructure', function (): void {
-    /** @var Backup $backup */
-    $backup = Backup::factory()->create();
+        /** @var Backup $backup */
+        $backup = Backup::factory()->create([
+            'infrastructure_id' => $infrastructure->id,
+        ]);
 
-    expect($backup->infrastructure)
-        ->toBeInstanceOf(Infrastructure::class);
-});
+        expect($backup->infrastructure)->toBeInstanceOf(Infrastructure::class)
+            ->and($backup->infrastructure->id)->toBe($infrastructure->id);
+    });
+
+test('casts attributes correctly',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var Backup $backup */
+        $backup = Backup::factory()->create([
+            'status' => InfrastructureStatus::Healthy,
+        ]);
+
+        expect($backup->id)->toBeString()
+            ->and($backup->created_at)->toBeInstanceOf(CarbonImmutable::class)
+            ->and($backup->updated_at)->toBeInstanceOf(CarbonImmutable::class)
+            ->and($backup->status)->toBe(InfrastructureStatus::Healthy);
+    });
+
+test('uses uuid for primary key',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var Backup $backup */
+        $backup = Backup::factory()->create();
+
+        expect($backup->id)
+            ->toBeString()
+            ->toBeUuid();
+    });
+
+test('to array has all fields in correct order',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var Backup $backup */
+        $backup = Backup::factory()
+            ->create()
+            ->refresh();
+
+        expect(array_keys($backup->toArray()))
+            ->toBe([
+                'id',
+                'created_at',
+                'updated_at',
+                'infrastructure_id',
+                'name',
+                'external_backup_id',
+                'status',
+            ]);
+    });

--- a/tests/Unit/Models/FirewallTest.php
+++ b/tests/Unit/Models/FirewallTest.php
@@ -5,39 +5,87 @@ declare(strict_types=1);
 use App\Enums\InfrastructureStatus;
 use App\Models\Firewall;
 use App\Models\Infrastructure;
+use Carbon\CarbonImmutable;
 
-test('to array', function (): void {
-
-    /** @var Firewall $firewall */
-    $firewall = Firewall::factory()
-        ->create()
-        ->fresh();
-
-    expect(array_keys($firewall->toArray()))
-        ->toBe([
-            'id',
-            'created_at',
-            'updated_at',
-            'infrastructure_id',
-            'name',
-            'external_firewall_id',
-            'status',
+test('creates firewall',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var Firewall $firewall */
+        $firewall = Firewall::factory()->create([
+            'name' => 'web-firewall',
         ]);
-});
 
-test('status is cast to enum', function (): void {
-    /** @var Firewall $firewall */
-    $firewall = Firewall::factory()->create([
-        'status' => InfrastructureStatus::Healthy,
-    ]);
+        expect($firewall->name)->toBe('web-firewall')
+            ->and($firewall->id)->toBeString()
+            ->and($firewall->created_at)->toBeInstanceOf(CarbonImmutable::class);
+    });
 
-    expect($firewall->status)->toBe(InfrastructureStatus::Healthy);
-});
+test('belongs to infrastructure',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var Infrastructure $infrastructure */
+        $infrastructure = Infrastructure::factory()->create();
 
-test('belongs to infrastructure', function (): void {
-    /** @var Firewall $firewall */
-    $firewall = Firewall::factory()->create();
+        /** @var Firewall $firewall */
+        $firewall = Firewall::factory()->create([
+            'infrastructure_id' => $infrastructure->id,
+        ]);
 
-    expect($firewall->infrastructure)
-        ->toBeInstanceOf(Infrastructure::class);
-});
+        expect($firewall->infrastructure)->toBeInstanceOf(Infrastructure::class)
+            ->and($firewall->infrastructure->id)->toBe($infrastructure->id);
+    });
+
+test('casts attributes correctly',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var Firewall $firewall */
+        $firewall = Firewall::factory()->create([
+            'status' => InfrastructureStatus::Healthy,
+        ]);
+
+        expect($firewall->id)->toBeString()
+            ->and($firewall->created_at)->toBeInstanceOf(CarbonImmutable::class)
+            ->and($firewall->updated_at)->toBeInstanceOf(CarbonImmutable::class)
+            ->and($firewall->status)->toBe(InfrastructureStatus::Healthy);
+    });
+
+test('uses uuid for primary key',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var Firewall $firewall */
+        $firewall = Firewall::factory()->create();
+
+        expect($firewall->id)
+            ->toBeString()
+            ->toBeUuid();
+    });
+
+test('to array has all fields in correct order',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var Firewall $firewall */
+        $firewall = Firewall::factory()
+            ->create()
+            ->refresh();
+
+        expect(array_keys($firewall->toArray()))
+            ->toBe([
+                'id',
+                'created_at',
+                'updated_at',
+                'infrastructure_id',
+                'name',
+                'external_firewall_id',
+                'status',
+            ]);
+    });

--- a/tests/Unit/Models/LoadBalancerTest.php
+++ b/tests/Unit/Models/LoadBalancerTest.php
@@ -5,40 +5,88 @@ declare(strict_types=1);
 use App\Enums\InfrastructureStatus;
 use App\Models\Infrastructure;
 use App\Models\LoadBalancer;
+use Carbon\CarbonImmutable;
 
-test('to array', function (): void {
-
-    /** @var LoadBalancer $loadBalancer */
-    $loadBalancer = LoadBalancer::factory()
-        ->create()
-        ->fresh();
-
-    expect(array_keys($loadBalancer->toArray()))
-        ->toBe([
-            'id',
-            'created_at',
-            'updated_at',
-            'infrastructure_id',
-            'name',
-            'external_load_balancer_id',
-            'ip',
-            'status',
+test('creates load balancer',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var LoadBalancer $loadBalancer */
+        $loadBalancer = LoadBalancer::factory()->create([
+            'name' => 'main-lb',
         ]);
-});
 
-test('status is cast to enum', function (): void {
-    /** @var LoadBalancer $loadBalancer */
-    $loadBalancer = LoadBalancer::factory()->create([
-        'status' => InfrastructureStatus::Healthy,
-    ]);
+        expect($loadBalancer->name)->toBe('main-lb')
+            ->and($loadBalancer->id)->toBeString()
+            ->and($loadBalancer->created_at)->toBeInstanceOf(CarbonImmutable::class);
+    });
 
-    expect($loadBalancer->status)->toBe(InfrastructureStatus::Healthy);
-});
+test('belongs to infrastructure',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var Infrastructure $infrastructure */
+        $infrastructure = Infrastructure::factory()->create();
 
-test('belongs to infrastructure', function (): void {
-    /** @var LoadBalancer $loadBalancer */
-    $loadBalancer = LoadBalancer::factory()->create();
+        /** @var LoadBalancer $loadBalancer */
+        $loadBalancer = LoadBalancer::factory()->create([
+            'infrastructure_id' => $infrastructure->id,
+        ]);
 
-    expect($loadBalancer->infrastructure)
-        ->toBeInstanceOf(Infrastructure::class);
-});
+        expect($loadBalancer->infrastructure)->toBeInstanceOf(Infrastructure::class)
+            ->and($loadBalancer->infrastructure->id)->toBe($infrastructure->id);
+    });
+
+test('casts attributes correctly',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var LoadBalancer $loadBalancer */
+        $loadBalancer = LoadBalancer::factory()->create([
+            'status' => InfrastructureStatus::Healthy,
+        ]);
+
+        expect($loadBalancer->id)->toBeString()
+            ->and($loadBalancer->created_at)->toBeInstanceOf(CarbonImmutable::class)
+            ->and($loadBalancer->updated_at)->toBeInstanceOf(CarbonImmutable::class)
+            ->and($loadBalancer->status)->toBe(InfrastructureStatus::Healthy);
+    });
+
+test('uses uuid for primary key',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var LoadBalancer $loadBalancer */
+        $loadBalancer = LoadBalancer::factory()->create();
+
+        expect($loadBalancer->id)
+            ->toBeString()
+            ->toBeUuid();
+    });
+
+test('to array has all fields in correct order',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var LoadBalancer $loadBalancer */
+        $loadBalancer = LoadBalancer::factory()
+            ->create()
+            ->refresh();
+
+        expect(array_keys($loadBalancer->toArray()))
+            ->toBe([
+                'id',
+                'created_at',
+                'updated_at',
+                'infrastructure_id',
+                'name',
+                'external_load_balancer_id',
+                'ip',
+                'status',
+            ]);
+    });

--- a/tests/Unit/Models/NetworkTest.php
+++ b/tests/Unit/Models/NetworkTest.php
@@ -5,40 +5,88 @@ declare(strict_types=1);
 use App\Enums\InfrastructureStatus;
 use App\Models\Infrastructure;
 use App\Models\Network;
+use Carbon\CarbonImmutable;
 
-test('to array', function (): void {
-
-    /** @var Network $network */
-    $network = Network::factory()
-        ->create()
-        ->fresh();
-
-    expect(array_keys($network->toArray()))
-        ->toBe([
-            'id',
-            'created_at',
-            'updated_at',
-            'infrastructure_id',
-            'name',
-            'external_network_id',
-            'cidr',
-            'status',
+test('creates network',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var Network $network */
+        $network = Network::factory()->create([
+            'name' => 'internal-net',
         ]);
-});
 
-test('status is cast to enum', function (): void {
-    /** @var Network $network */
-    $network = Network::factory()->create([
-        'status' => InfrastructureStatus::Healthy,
-    ]);
+        expect($network->name)->toBe('internal-net')
+            ->and($network->id)->toBeString()
+            ->and($network->created_at)->toBeInstanceOf(CarbonImmutable::class);
+    });
 
-    expect($network->status)->toBe(InfrastructureStatus::Healthy);
-});
+test('belongs to infrastructure',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var Infrastructure $infrastructure */
+        $infrastructure = Infrastructure::factory()->create();
 
-test('belongs to infrastructure', function (): void {
-    /** @var Network $network */
-    $network = Network::factory()->create();
+        /** @var Network $network */
+        $network = Network::factory()->create([
+            'infrastructure_id' => $infrastructure->id,
+        ]);
 
-    expect($network->infrastructure)
-        ->toBeInstanceOf(Infrastructure::class);
-});
+        expect($network->infrastructure)->toBeInstanceOf(Infrastructure::class)
+            ->and($network->infrastructure->id)->toBe($infrastructure->id);
+    });
+
+test('casts attributes correctly',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var Network $network */
+        $network = Network::factory()->create([
+            'status' => InfrastructureStatus::Healthy,
+        ]);
+
+        expect($network->id)->toBeString()
+            ->and($network->created_at)->toBeInstanceOf(CarbonImmutable::class)
+            ->and($network->updated_at)->toBeInstanceOf(CarbonImmutable::class)
+            ->and($network->status)->toBe(InfrastructureStatus::Healthy);
+    });
+
+test('uses uuid for primary key',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var Network $network */
+        $network = Network::factory()->create();
+
+        expect($network->id)
+            ->toBeString()
+            ->toBeUuid();
+    });
+
+test('to array has all fields in correct order',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var Network $network */
+        $network = Network::factory()
+            ->create()
+            ->refresh();
+
+        expect(array_keys($network->toArray()))
+            ->toBe([
+                'id',
+                'created_at',
+                'updated_at',
+                'infrastructure_id',
+                'name',
+                'external_network_id',
+                'cidr',
+                'status',
+            ]);
+    });

--- a/tests/Unit/Models/SshKeyTest.php
+++ b/tests/Unit/Models/SshKeyTest.php
@@ -4,30 +4,84 @@ declare(strict_types=1);
 
 use App\Models\Infrastructure;
 use App\Models\SshKey;
+use Carbon\CarbonImmutable;
 
-test('to array', function (): void {
-
-    /** @var SshKey $sshKey */
-    $sshKey = SshKey::factory()
-        ->create()
-        ->fresh();
-
-    expect(array_keys($sshKey->toArray()))
-        ->toBe([
-            'id',
-            'created_at',
-            'updated_at',
-            'infrastructure_id',
-            'name',
-            'fingerprint',
-            'public_key',
+test('creates ssh key',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var SshKey $sshKey */
+        $sshKey = SshKey::factory()->create([
+            'name' => 'deploy-key',
         ]);
-});
 
-test('belongs to infrastructure', function (): void {
-    /** @var SshKey $sshKey */
-    $sshKey = SshKey::factory()->create();
+        expect($sshKey->name)->toBe('deploy-key')
+            ->and($sshKey->id)->toBeString()
+            ->and($sshKey->created_at)->toBeInstanceOf(CarbonImmutable::class);
+    });
 
-    expect($sshKey->infrastructure)
-        ->toBeInstanceOf(Infrastructure::class);
-});
+test('belongs to infrastructure',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var Infrastructure $infrastructure */
+        $infrastructure = Infrastructure::factory()->create();
+
+        /** @var SshKey $sshKey */
+        $sshKey = SshKey::factory()->create([
+            'infrastructure_id' => $infrastructure->id,
+        ]);
+
+        expect($sshKey->infrastructure)->toBeInstanceOf(Infrastructure::class)
+            ->and($sshKey->infrastructure->id)->toBe($infrastructure->id);
+    });
+
+test('casts attributes correctly',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var SshKey $sshKey */
+        $sshKey = SshKey::factory()->create();
+
+        expect($sshKey->id)->toBeString()
+            ->and($sshKey->created_at)->toBeInstanceOf(CarbonImmutable::class)
+            ->and($sshKey->updated_at)->toBeInstanceOf(CarbonImmutable::class);
+    });
+
+test('uses uuid for primary key',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var SshKey $sshKey */
+        $sshKey = SshKey::factory()->create();
+
+        expect($sshKey->id)
+            ->toBeString()
+            ->toBeUuid();
+    });
+
+test('to array has all fields in correct order',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var SshKey $sshKey */
+        $sshKey = SshKey::factory()
+            ->create()
+            ->refresh();
+
+        expect(array_keys($sshKey->toArray()))
+            ->toBe([
+                'id',
+                'created_at',
+                'updated_at',
+                'infrastructure_id',
+                'name',
+                'fingerprint',
+                'public_key',
+            ]);
+    });

--- a/tests/Unit/Models/StorageTest.php
+++ b/tests/Unit/Models/StorageTest.php
@@ -5,49 +5,90 @@ declare(strict_types=1);
 use App\Enums\InfrastructureStatus;
 use App\Models\Infrastructure;
 use App\Models\Storage;
+use Carbon\CarbonImmutable;
 
-test('to array', function (): void {
-
-    /** @var Storage $storage */
-    $storage = Storage::factory()
-        ->create()
-        ->fresh();
-
-    expect(array_keys($storage->toArray()))
-        ->toBe([
-            'id',
-            'created_at',
-            'updated_at',
-            'infrastructure_id',
-            'name',
-            'external_volume_id',
-            'size_gb',
-            'status',
+test('creates storage',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var Storage $storage */
+        $storage = Storage::factory()->create([
+            'name' => 'data-vol',
         ]);
-});
 
-test('status is cast to enum', function (): void {
-    /** @var Storage $storage */
-    $storage = Storage::factory()->create([
-        'status' => InfrastructureStatus::Healthy,
-    ]);
+        expect($storage->name)->toBe('data-vol')
+            ->and($storage->id)->toBeString()
+            ->and($storage->created_at)->toBeInstanceOf(CarbonImmutable::class);
+    });
 
-    expect($storage->status)->toBe(InfrastructureStatus::Healthy);
-});
+test('belongs to infrastructure',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var Infrastructure $infrastructure */
+        $infrastructure = Infrastructure::factory()->create();
 
-test('size gb is cast to integer', function (): void {
-    /** @var Storage $storage */
-    $storage = Storage::factory()->create([
-        'size_gb' => 500,
-    ]);
+        /** @var Storage $storage */
+        $storage = Storage::factory()->create([
+            'infrastructure_id' => $infrastructure->id,
+        ]);
 
-    expect($storage->size_gb)->toBe(500);
-});
+        expect($storage->infrastructure)->toBeInstanceOf(Infrastructure::class)
+            ->and($storage->infrastructure->id)->toBe($infrastructure->id);
+    });
 
-test('belongs to infrastructure', function (): void {
-    /** @var Storage $storage */
-    $storage = Storage::factory()->create();
+test('casts attributes correctly',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var Storage $storage */
+        $storage = Storage::factory()->create([
+            'status' => InfrastructureStatus::Healthy,
+            'size_gb' => 500,
+        ]);
 
-    expect($storage->infrastructure)
-        ->toBeInstanceOf(Infrastructure::class);
-});
+        expect($storage->id)->toBeString()
+            ->and($storage->created_at)->toBeInstanceOf(CarbonImmutable::class)
+            ->and($storage->updated_at)->toBeInstanceOf(CarbonImmutable::class)
+            ->and($storage->status)->toBe(InfrastructureStatus::Healthy)
+            ->and($storage->size_gb)->toBe(500);
+    });
+
+test('uses uuid for primary key',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var Storage $storage */
+        $storage = Storage::factory()->create();
+
+        expect($storage->id)
+            ->toBeString()
+            ->toBeUuid();
+    });
+
+test('to array has all fields in correct order',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var Storage $storage */
+        $storage = Storage::factory()
+            ->create()
+            ->refresh();
+
+        expect(array_keys($storage->toArray()))
+            ->toBe([
+                'id',
+                'created_at',
+                'updated_at',
+                'infrastructure_id',
+                'name',
+                'external_volume_id',
+                'size_gb',
+                'status',
+            ]);
+    });


### PR DESCRIPTION
## Summary

- Aligns 6 model test files (Network, Firewall, LoadBalancer, Storage, Backup, SshKey) with `tests/CONTRIBUTING.md` conventions
- Adds mandatory tests: "creates model", "casts attributes correctly", "uses uuid for primary key"
- Reorders tests: creates model → relationships → casts → uuid → toArray (last)
- Renames toArray test to "to array has all fields in correct order"
- Adds `@throws Throwable` on closures that touch the database
- Adds `/** @var */` type hints on factory variables
- Upgrades relationship tests to create related models and verify link
- Uses `create()->refresh()` instead of `create()->fresh()` in toArray tests

Closes #9

## Test plan

- [x] `php artisan test --compact tests/Unit/Models/{Network,Firewall,LoadBalancer,Storage,Backup,SshKey}Test.php` — 30 tests, 72 assertions pass
- [x] `vendor/bin/pint --dirty --format agent` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)