### PR TITLE
Align KubernetesCluster and Region model tests with CONTRIBUTING.md

### DIFF
--- a/tests/Unit/Models/KubernetesClusterTest.php
+++ b/tests/Unit/Models/KubernetesClusterTest.php
@@ -5,47 +5,107 @@ declare(strict_types=1);
 use App\Enums\InfrastructureStatus;
 use App\Models\Infrastructure;
 use App\Models\KubernetesCluster;
+use App\Models\Server;
+use Carbon\CarbonImmutable;
 
-test('to array', function (): void {
-
-    /** @var KubernetesCluster $cluster */
-    $cluster = KubernetesCluster::factory()
-        ->create()
-        ->fresh();
-
-    expect(array_keys($cluster->toArray()))
-        ->toBe([
-            'id',
-            'created_at',
-            'updated_at',
-            'infrastructure_id',
-            'name',
-            'version',
-            'external_cluster_id',
-            'status',
+test('creates kubernetes cluster',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var KubernetesCluster $cluster */
+        $cluster = KubernetesCluster::factory()->create([
+            'name' => 'prod-cluster',
         ]);
-});
 
-test('status is cast to enum', function (): void {
-    /** @var KubernetesCluster $cluster */
-    $cluster = KubernetesCluster::factory()->create([
-        'status' => InfrastructureStatus::Healthy,
-    ]);
+        expect($cluster->name)->toBe('prod-cluster')
+            ->and($cluster->id)->toBeString()
+            ->and($cluster->created_at)->toBeInstanceOf(CarbonImmutable::class);
+    });
 
-    expect($cluster->status)->toBe(InfrastructureStatus::Healthy);
-});
+test('belongs to infrastructure',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var Infrastructure $infrastructure */
+        $infrastructure = Infrastructure::factory()->create();
 
-test('belongs to infrastructure', function (): void {
-    /** @var KubernetesCluster $cluster */
-    $cluster = KubernetesCluster::factory()->create();
+        /** @var KubernetesCluster $cluster */
+        $cluster = KubernetesCluster::factory()->create([
+            'infrastructure_id' => $infrastructure->id,
+        ]);
 
-    expect($cluster->infrastructure)
-        ->toBeInstanceOf(Infrastructure::class);
-});
+        expect($cluster->infrastructure)->toBeInstanceOf(Infrastructure::class)
+            ->and($cluster->infrastructure->id)->toBe($infrastructure->id);
+    });
 
-test('has many nodes', function (): void {
-    /** @var KubernetesCluster $cluster */
-    $cluster = KubernetesCluster::factory()->create();
+test('has many nodes',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var KubernetesCluster $cluster */
+        $cluster = KubernetesCluster::factory()->create();
 
-    expect($cluster->nodes)->toBeEmpty();
-});
+        /** @var Server $server */
+        $server = Server::factory()->create([
+            'kubernetes_cluster_id' => $cluster->id,
+        ]);
+
+        expect($cluster->nodes)->toHaveCount(1)
+            ->and($cluster->nodes->first())->toBeInstanceOf(Server::class)
+            ->and($cluster->nodes->first()->id)->toBe($server->id);
+    });
+
+test('casts attributes correctly',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var KubernetesCluster $cluster */
+        $cluster = KubernetesCluster::factory()->create([
+            'status' => InfrastructureStatus::Healthy,
+        ]);
+
+        expect($cluster->id)->toBeString()
+            ->and($cluster->created_at)->toBeInstanceOf(CarbonImmutable::class)
+            ->and($cluster->updated_at)->toBeInstanceOf(CarbonImmutable::class)
+            ->and($cluster->status)->toBe(InfrastructureStatus::Healthy);
+    });
+
+test('uses uuid for primary key',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var KubernetesCluster $cluster */
+        $cluster = KubernetesCluster::factory()->create();
+
+        expect($cluster->id)
+            ->toBeString()
+            ->toBeUuid();
+    });
+
+test('to array has all fields in correct order',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var KubernetesCluster $cluster */
+        $cluster = KubernetesCluster::factory()
+            ->create()
+            ->refresh();
+
+        expect(array_keys($cluster->toArray()))
+            ->toBe([
+                'id',
+                'created_at',
+                'updated_at',
+                'infrastructure_id',
+                'name',
+                'version',
+                'external_cluster_id',
+                'status',
+            ]);
+    });

--- a/tests/Unit/Models/RegionTest.php
+++ b/tests/Unit/Models/RegionTest.php
@@ -3,38 +3,104 @@
 declare(strict_types=1);
 
 use App\Models\CloudProvider;
+use App\Models\Infrastructure;
 use App\Models\Region;
+use Carbon\CarbonImmutable;
 
-test('to array', function (): void {
-
-    /** @var Region $region */
-    $region = Region::factory()
-        ->create()
-        ->fresh();
-
-    expect(array_keys($region->toArray()))
-        ->toBe([
-            'id',
-            'created_at',
-            'updated_at',
-            'cloud_provider_id',
-            'internal_name',
-            'provider_region',
-            'description',
+test('creates region',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var Region $region */
+        $region = Region::factory()->create([
+            'internal_name' => 'eu-central',
         ]);
-});
 
-test('belongs to cloud provider', function (): void {
-    /** @var Region $region */
-    $region = Region::factory()->create();
+        expect($region->internal_name)->toBe('eu-central')
+            ->and($region->id)->toBeString()
+            ->and($region->created_at)->toBeInstanceOf(CarbonImmutable::class);
+    });
 
-    expect($region->cloudProvider)
-        ->toBeInstanceOf(CloudProvider::class);
-});
+test('belongs to cloud provider',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var CloudProvider $cloudProvider */
+        $cloudProvider = CloudProvider::factory()->create();
 
-test('has many infrastructures', function (): void {
-    /** @var Region $region */
-    $region = Region::factory()->create();
+        /** @var Region $region */
+        $region = Region::factory()->create([
+            'cloud_provider_id' => $cloudProvider->id,
+        ]);
 
-    expect($region->infrastructures)->toBeEmpty();
-});
+        expect($region->cloudProvider)->toBeInstanceOf(CloudProvider::class)
+            ->and($region->cloudProvider->id)->toBe($cloudProvider->id);
+    });
+
+test('has many infrastructures',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var Region $region */
+        $region = Region::factory()->create();
+
+        /** @var Infrastructure $infrastructure */
+        $infrastructure = Infrastructure::factory()->create([
+            'region_id' => $region->id,
+        ]);
+
+        expect($region->infrastructures)->toHaveCount(1)
+            ->and($region->infrastructures->first())->toBeInstanceOf(Infrastructure::class)
+            ->and($region->infrastructures->first()->id)->toBe($infrastructure->id);
+    });
+
+test('casts attributes correctly',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var Region $region */
+        $region = Region::factory()->create();
+
+        expect($region->id)->toBeString()
+            ->and($region->created_at)->toBeInstanceOf(CarbonImmutable::class)
+            ->and($region->updated_at)->toBeInstanceOf(CarbonImmutable::class);
+    });
+
+test('uses uuid for primary key',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var Region $region */
+        $region = Region::factory()->create();
+
+        expect($region->id)
+            ->toBeString()
+            ->toBeUuid();
+    });
+
+test('to array has all fields in correct order',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var Region $region */
+        $region = Region::factory()
+            ->create()
+            ->refresh();
+
+        expect(array_keys($region->toArray()))
+            ->toBe([
+                'id',
+                'created_at',
+                'updated_at',
+                'cloud_provider_id',
+                'internal_name',
+                'provider_region',
+                'description',
+            ]);
+    });


### PR DESCRIPTION
## Summary

- Aligns KubernetesClusterTest and RegionTest with `tests/CONTRIBUTING.md` conventions
- Adds mandatory tests: "creates model", "casts attributes correctly", "uses uuid for primary key"
- Reorders tests: creates model → relationships → casts → uuid → toArray (last)
- Renames toArray test to "to array has all fields in correct order"
- Adds `@throws Throwable` on closures that touch the database
- Adds `/** @var */` type hints on factory variables
- Upgrades relationship tests: "has many nodes" creates a Server and verifies link, "has many infrastructures" creates an Infrastructure and verifies link
- Uses `create()->refresh()` instead of `create()->fresh()` in toArray tests

Closes #10

## Test plan

- [x] `php artisan test --compact tests/Unit/Models/{KubernetesCluster,Region}Test.php` — 12 tests, 29 assertions pass
- [x] `vendor/bin/pint --dirty --format agent` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)