### PR TITLE
Align Organization and Server model tests with CONTRIBUTING.md

### DIFF
--- a/tests/Unit/Models/OrganizationTest.php
+++ b/tests/Unit/Models/OrganizationTest.php
@@ -2,43 +2,125 @@
 
 declare(strict_types=1);
 
+use App\Models\CloudProvider;
+use App\Models\Infrastructure;
 use App\Models\Organization;
 use App\Models\Server;
+use Carbon\CarbonImmutable;
 
-test('to array', function (): void {
-
-    /** @var Organization $organization */
-    $organization = Organization::factory()
-        ->create()
-        ->fresh();
-
-    expect(array_keys($organization->toArray()))
-        ->toBe([
-            'id',
-            'created_at',
-            'updated_at',
-            'name',
-            'slug',
-            'logo',
-            'description',
+test('creates organization',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var Organization $organization */
+        $organization = Organization::factory()->create([
+            'name' => 'Acme Corp',
         ]);
-});
 
-test('has servers relationship', function (): void {
-    $organization = Organization::factory()->create();
-    Server::factory()->create(['organization_id' => $organization->id]);
+        expect($organization->name)->toBe('Acme Corp')
+            ->and($organization->id)->toBeString()
+            ->and($organization->created_at)->toBeInstanceOf(CarbonImmutable::class);
+    });
 
-    expect($organization->servers)->toHaveCount(1);
-});
+test('has many servers',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var Organization $organization */
+        $organization = Organization::factory()->create();
 
-test('has cloud providers relationship', function (): void {
-    $organization = Organization::factory()->create();
+        /** @var Server $server */
+        $server = Server::factory()->create([
+            'organization_id' => $organization->id,
+        ]);
 
-    expect($organization->cloudProviders)->toBeEmpty();
-});
+        expect($organization->servers)->toHaveCount(1)
+            ->and($organization->servers->first())->toBeInstanceOf(Server::class)
+            ->and($organization->servers->first()->id)->toBe($server->id);
+    });
 
-test('has infrastructures relationship', function (): void {
-    $organization = Organization::factory()->create();
+test('has many cloud providers',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var Organization $organization */
+        $organization = Organization::factory()->create();
 
-    expect($organization->infrastructures)->toBeEmpty();
-});
+        /** @var CloudProvider $cloudProvider */
+        $cloudProvider = CloudProvider::factory()->create([
+            'organization_id' => $organization->id,
+        ]);
+
+        expect($organization->cloudProviders)->toHaveCount(1)
+            ->and($organization->cloudProviders->first())->toBeInstanceOf(CloudProvider::class)
+            ->and($organization->cloudProviders->first()->id)->toBe($cloudProvider->id);
+    });
+
+test('has many infrastructures',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var Organization $organization */
+        $organization = Organization::factory()->create();
+
+        /** @var Infrastructure $infrastructure */
+        $infrastructure = Infrastructure::factory()->create([
+            'organization_id' => $organization->id,
+        ]);
+
+        expect($organization->infrastructures)->toHaveCount(1)
+            ->and($organization->infrastructures->first())->toBeInstanceOf(Infrastructure::class)
+            ->and($organization->infrastructures->first()->id)->toBe($infrastructure->id);
+    });
+
+test('casts attributes correctly',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var Organization $organization */
+        $organization = Organization::factory()->create();
+
+        expect($organization->id)->toBeString()
+            ->and($organization->created_at)->toBeInstanceOf(CarbonImmutable::class)
+            ->and($organization->updated_at)->toBeInstanceOf(CarbonImmutable::class);
+    });
+
+test('uses uuid for primary key',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var Organization $organization */
+        $organization = Organization::factory()->create();
+
+        expect($organization->id)
+            ->toBeString()
+            ->toBeUuid();
+    });
+
+test('to array has all fields in correct order',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var Organization $organization */
+        $organization = Organization::factory()
+            ->create()
+            ->refresh();
+
+        expect(array_keys($organization->toArray()))
+            ->toBe([
+                'id',
+                'created_at',
+                'updated_at',
+                'name',
+                'slug',
+                'logo',
+                'description',
+            ]);
+    });

--- a/tests/Unit/Models/ServerTest.php
+++ b/tests/Unit/Models/ServerTest.php
@@ -4,65 +4,149 @@ declare(strict_types=1);
 
 use App\Enums\ServerStatus;
 use App\Models\CloudProvider;
+use App\Models\Infrastructure;
+use App\Models\KubernetesCluster;
 use App\Models\Organization;
 use App\Models\Server;
+use Carbon\CarbonImmutable;
 
-test('to array', function (): void {
-
-    /** @var Server $server */
-    $server = Server::factory()
-        ->create()
-        ->fresh();
-
-    expect(array_keys($server->toArray()))
-        ->toBe([
-            'id',
-            'created_at',
-            'updated_at',
-            'organization_id',
-            'cloud_provider_id',
-            'external_id',
-            'name',
-            'status',
-            'type',
-            'region',
-            'ipv4',
-            'ipv6',
-            'metadata',
-            'infrastructure_id',
-            'kubernetes_cluster_id',
-            'role',
+test('creates server',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var Server $server */
+        $server = Server::factory()->create([
+            'name' => 'web-1',
         ]);
-});
 
-test('status is cast to enum', function (): void {
-    $server = Server::factory()->running()->create();
+        expect($server->name)->toBe('web-1')
+            ->and($server->id)->toBeString()
+            ->and($server->created_at)->toBeInstanceOf(CarbonImmutable::class);
+    });
 
-    expect($server->status)->toBe(ServerStatus::Running);
-});
+test('belongs to organization',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var Organization $organization */
+        $organization = Organization::factory()->create();
 
-test('belongs to organization', function (): void {
-    $server = Server::factory()->create();
+        /** @var Server $server */
+        $server = Server::factory()->create([
+            'organization_id' => $organization->id,
+        ]);
 
-    expect($server->organization)->toBeInstanceOf(Organization::class);
-});
+        expect($server->organization)->toBeInstanceOf(Organization::class)
+            ->and($server->organization->id)->toBe($organization->id);
+    });
 
-test('belongs to cloud provider', function (): void {
-    $server = Server::factory()->create();
+test('belongs to cloud provider',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var CloudProvider $cloudProvider */
+        $cloudProvider = CloudProvider::factory()->create();
 
-    expect($server->cloudProvider)->toBeInstanceOf(CloudProvider::class);
-});
+        /** @var Server $server */
+        $server = Server::factory()->create([
+            'cloud_provider_id' => $cloudProvider->id,
+        ]);
 
-test('belongs to infrastructure', function (): void {
-    /** @var Server $server */
-    $server = Server::factory()->create();
+        expect($server->cloudProvider)->toBeInstanceOf(CloudProvider::class)
+            ->and($server->cloudProvider->id)->toBe($cloudProvider->id);
+    });
 
-    expect($server->infrastructure)->not->toBeNull();
-});
+test('belongs to infrastructure',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var Infrastructure $infrastructure */
+        $infrastructure = Infrastructure::factory()->create();
 
-test('belongs to kubernetes cluster', function (): void {
-    /** @var Server $server */
-    $server = Server::factory()->create();
+        /** @var Server $server */
+        $server = Server::factory()->create([
+            'infrastructure_id' => $infrastructure->id,
+        ]);
 
-    expect($server->kubernetesCluster)->toBeNull();
-});
+        expect($server->infrastructure)->toBeInstanceOf(Infrastructure::class)
+            ->and($server->infrastructure->id)->toBe($infrastructure->id);
+    });
+
+test('belongs to kubernetes cluster',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var KubernetesCluster $cluster */
+        $cluster = KubernetesCluster::factory()->create();
+
+        /** @var Server $server */
+        $server = Server::factory()->create([
+            'kubernetes_cluster_id' => $cluster->id,
+        ]);
+
+        expect($server->kubernetesCluster)->toBeInstanceOf(KubernetesCluster::class)
+            ->and($server->kubernetesCluster->id)->toBe($cluster->id);
+    });
+
+test('casts attributes correctly',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var Server $server */
+        $server = Server::factory()->running()->create();
+
+        expect($server->id)->toBeString()
+            ->and($server->created_at)->toBeInstanceOf(CarbonImmutable::class)
+            ->and($server->updated_at)->toBeInstanceOf(CarbonImmutable::class)
+            ->and($server->status)->toBe(ServerStatus::Running);
+    });
+
+test('uses uuid for primary key',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var Server $server */
+        $server = Server::factory()->create();
+
+        expect($server->id)
+            ->toBeString()
+            ->toBeUuid();
+    });
+
+test('to array has all fields in correct order',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var Server $server */
+        $server = Server::factory()
+            ->create()
+            ->refresh();
+
+        expect(array_keys($server->toArray()))
+            ->toBe([
+                'id',
+                'created_at',
+                'updated_at',
+                'organization_id',
+                'cloud_provider_id',
+                'external_id',
+                'name',
+                'status',
+                'type',
+                'region',
+                'ipv4',
+                'ipv6',
+                'metadata',
+                'infrastructure_id',
+                'kubernetes_cluster_id',
+                'role',
+            ]);
+    });


### PR DESCRIPTION
## Summary

- Aligns OrganizationTest and ServerTest with `tests/CONTRIBUTING.md` conventions
- Adds mandatory tests: "creates model", "casts attributes correctly", "uses uuid for primary key"
- Reorders tests: creates model → relationships → casts → uuid → toArray (last)
- Renames toArray test to "to array has all fields in correct order"
- Adds `@throws Throwable` on closures that touch the database
- Adds `/** @var */` type hints on all factory variables
- Upgrades all relationship tests to create related models and verify link + ID match
- ServerTest: replaces nullable KubernetesCluster test with assigned relationship test
- OrganizationTest: upgrades cloudProviders and infrastructures tests to create related models
- Uses `create()->refresh()` instead of `create()->fresh()` in toArray tests

Closes #11

## Test plan

- [x] `php artisan test --compact tests/Unit/Models/{Organization,Server}Test.php` — 15 tests, 36 assertions pass
- [x] `vendor/bin/pint --dirty --format agent` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)