### PR TITLE
Align CloudProvider and Infrastructure model tests with CONTRIBUTING.md

### DIFF
--- a/tests/Unit/Models/CloudProviderTest.php
+++ b/tests/Unit/Models/CloudProviderTest.php
@@ -4,74 +4,171 @@ declare(strict_types=1);
 
 use App\Enums\CloudProviderType;
 use App\Models\CloudProvider;
+use App\Models\Infrastructure;
 use App\Models\Organization;
+use App\Models\Region;
+use App\Models\Server;
+use Carbon\CarbonImmutable;
+use Illuminate\Support\Facades\DB;
 
-test('to array', function (): void {
-
-    /** @var CloudProvider $cloudProvider */
-    $cloudProvider = CloudProvider::factory()
-        ->create()
-        ->fresh();
-
-    expect(array_keys($cloudProvider->toArray()))
-        ->toBe([
-            'id',
-            'created_at',
-            'updated_at',
-            'organization_id',
-            'name',
-            'type',
-            'api_token',
-            'is_verified',
+test('creates cloud provider',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var CloudProvider $cloudProvider */
+        $cloudProvider = CloudProvider::factory()->create([
+            'name' => 'My Hetzner',
         ]);
-});
 
-test('type is cast to enum', function (): void {
-    /** @var CloudProvider $cloudProvider */
-    $cloudProvider = CloudProvider::factory()->hetzner()->create();
+        expect($cloudProvider->name)->toBe('My Hetzner')
+            ->and($cloudProvider->id)->toBeString()
+            ->and($cloudProvider->created_at)->toBeInstanceOf(CarbonImmutable::class);
+    });
 
-    expect($cloudProvider->type)->toBe(CloudProviderType::Hetzner);
-});
+test('belongs to organization',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var Organization $organization */
+        $organization = Organization::factory()->create();
 
-test('api token is encrypted', function (): void {
-    /** @var CloudProvider $cloudProvider */
-    $cloudProvider = CloudProvider::factory()->create([
-        'api_token' => 'my-secret-token',
-    ]);
+        /** @var CloudProvider $cloudProvider */
+        $cloudProvider = CloudProvider::factory()->create([
+            'organization_id' => $organization->id,
+        ]);
 
-    $raw = DB::table('cloud_providers')
-        ->where('id', $cloudProvider->id)
-        ->value('api_token');
+        expect($cloudProvider->organization)->toBeInstanceOf(Organization::class)
+            ->and($cloudProvider->organization->id)->toBe($organization->id);
+    });
 
-    expect($raw)->not->toBe('my-secret-token')
-        ->and($cloudProvider->fresh()->api_token)->toBe('my-secret-token');
-});
+test('has many servers',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var CloudProvider $cloudProvider */
+        $cloudProvider = CloudProvider::factory()->create();
 
-test('belongs to organization', function (): void {
-    /** @var CloudProvider $cloudProvider */
-    $cloudProvider = CloudProvider::factory()->create();
+        /** @var Server $server */
+        $server = Server::factory()->create([
+            'cloud_provider_id' => $cloudProvider->id,
+        ]);
 
-    expect($cloudProvider->organization)
-        ->toBeInstanceOf(Organization::class);
-});
+        expect($cloudProvider->servers)->toHaveCount(1)
+            ->and($cloudProvider->servers->first())->toBeInstanceOf(Server::class)
+            ->and($cloudProvider->servers->first()->id)->toBe($server->id);
+    });
 
-test('has many servers', function (): void {
-    /** @var CloudProvider $cloudProvider */
-    $cloudProvider = CloudProvider::factory()->create();
+test('has many regions',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var CloudProvider $cloudProvider */
+        $cloudProvider = CloudProvider::factory()->create();
 
-    expect($cloudProvider->servers)->toBeEmpty();
-});
+        /** @var Region $region */
+        $region = Region::factory()->create([
+            'cloud_provider_id' => $cloudProvider->id,
+        ]);
 
-test('has many regions', function (): void {
-    /** @var CloudProvider $cloudProvider */
-    $cloudProvider = CloudProvider::factory()->create();
+        expect($cloudProvider->regions)->toHaveCount(1)
+            ->and($cloudProvider->regions->first())->toBeInstanceOf(Region::class)
+            ->and($cloudProvider->regions->first()->id)->toBe($region->id);
+    });
 
-    expect($cloudProvider->regions)->toBeEmpty();
-});
+test('has many infrastructures',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var CloudProvider $cloudProvider */
+        $cloudProvider = CloudProvider::factory()->create();
 
-test('has many infrastructures', function (): void {
-    /** @var CloudProvider $cloudProvider */
-    $cloudProvider = CloudProvider::factory()->create();
+        /** @var Infrastructure $infrastructure */
+        $infrastructure = Infrastructure::factory()->create([
+            'cloud_provider_id' => $cloudProvider->id,
+        ]);
 
-    expect($cloudProvider->infrastructures)->toBeEmpty();
-});
+        expect($cloudProvider->infrastructures)->toHaveCount(1)
+            ->and($cloudProvider->infrastructures->first())->toBeInstanceOf(Infrastructure::class)
+            ->and($cloudProvider->infrastructures->first()->id)->toBe($infrastructure->id);
+    });
+
+test('casts attributes correctly',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var CloudProvider $cloudProvider */
+        $cloudProvider = CloudProvider::factory()->hetzner()->create([
+            'api_token' => 'my-secret-token',
+        ]);
+
+        $raw = DB::table('cloud_providers')
+            ->where('id', $cloudProvider->id)
+            ->value('api_token');
+
+        expect($cloudProvider->id)->toBeString()
+            ->and($cloudProvider->created_at)->toBeInstanceOf(CarbonImmutable::class)
+            ->and($cloudProvider->updated_at)->toBeInstanceOf(CarbonImmutable::class)
+            ->and($cloudProvider->type)->toBe(CloudProviderType::Hetzner)
+            ->and($raw)->not->toBe('my-secret-token')
+            ->and($cloudProvider->fresh()->api_token)->toBe('my-secret-token');
+    });
+
+test('api token is encrypted',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var CloudProvider $cloudProvider */
+        $cloudProvider = CloudProvider::factory()->create([
+            'api_token' => 'my-secret-token',
+        ]);
+
+        $raw = DB::table('cloud_providers')
+            ->where('id', $cloudProvider->id)
+            ->value('api_token');
+
+        expect($raw)->not->toBe('my-secret-token')
+            ->and($cloudProvider->fresh()->api_token)->toBe('my-secret-token');
+    });
+
+test('uses uuid for primary key',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var CloudProvider $cloudProvider */
+        $cloudProvider = CloudProvider::factory()->create();
+
+        expect($cloudProvider->id)
+            ->toBeString()
+            ->toBeUuid();
+    });
+
+test('to array has all fields in correct order',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var CloudProvider $cloudProvider */
+        $cloudProvider = CloudProvider::factory()
+            ->create()
+            ->refresh();
+
+        expect(array_keys($cloudProvider->toArray()))
+            ->toBe([
+                'id',
+                'created_at',
+                'updated_at',
+                'organization_id',
+                'name',
+                'type',
+                'api_token',
+                'is_verified',
+            ]);
+    });

--- a/tests/Unit/Models/InfrastructureTest.php
+++ b/tests/Unit/Models/InfrastructureTest.php
@@ -3,115 +3,260 @@
 declare(strict_types=1);
 
 use App\Enums\InfrastructureStatus;
+use App\Models\Backup;
 use App\Models\CloudProvider;
+use App\Models\Firewall;
 use App\Models\Infrastructure;
+use App\Models\KubernetesCluster;
+use App\Models\LoadBalancer;
+use App\Models\Network;
 use App\Models\Organization;
 use App\Models\Region;
+use App\Models\SshKey;
+use App\Models\Storage;
+use Carbon\CarbonImmutable;
 
-test('to array', function (): void {
-
-    /** @var Infrastructure $infrastructure */
-    $infrastructure = Infrastructure::factory()
-        ->create()
-        ->fresh();
-
-    expect(array_keys($infrastructure->toArray()))
-        ->toBe([
-            'id',
-            'created_at',
-            'updated_at',
-            'organization_id',
-            'cloud_provider_id',
-            'region_id',
-            'name',
-            'description',
-            'status',
+test('creates infrastructure',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var Infrastructure $infrastructure */
+        $infrastructure = Infrastructure::factory()->create([
+            'name' => 'prod-infra',
         ]);
-});
 
-test('status is cast to enum', function (): void {
-    /** @var Infrastructure $infrastructure */
-    $infrastructure = Infrastructure::factory()->create([
-        'status' => InfrastructureStatus::Healthy,
-    ]);
+        expect($infrastructure->name)->toBe('prod-infra')
+            ->and($infrastructure->id)->toBeString()
+            ->and($infrastructure->created_at)->toBeInstanceOf(CarbonImmutable::class);
+    });
 
-    expect($infrastructure->status)->toBe(InfrastructureStatus::Healthy);
-});
+test('belongs to organization',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var Organization $organization */
+        $organization = Organization::factory()->create();
 
-test('belongs to organization', function (): void {
-    /** @var Infrastructure $infrastructure */
-    $infrastructure = Infrastructure::factory()->create();
+        /** @var Infrastructure $infrastructure */
+        $infrastructure = Infrastructure::factory()->create([
+            'organization_id' => $organization->id,
+        ]);
 
-    expect($infrastructure->organization)
-        ->toBeInstanceOf(Organization::class);
-});
+        expect($infrastructure->organization)->toBeInstanceOf(Organization::class)
+            ->and($infrastructure->organization->id)->toBe($organization->id);
+    });
 
-test('belongs to cloud provider', function (): void {
-    /** @var Infrastructure $infrastructure */
-    $infrastructure = Infrastructure::factory()->create();
+test('belongs to cloud provider',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var CloudProvider $cloudProvider */
+        $cloudProvider = CloudProvider::factory()->create();
 
-    expect($infrastructure->cloudProvider)
-        ->toBeInstanceOf(CloudProvider::class);
-});
+        /** @var Infrastructure $infrastructure */
+        $infrastructure = Infrastructure::factory()->create([
+            'cloud_provider_id' => $cloudProvider->id,
+        ]);
 
-test('belongs to region', function (): void {
-    /** @var Region $region */
-    $region = Region::factory()->create();
+        expect($infrastructure->cloudProvider)->toBeInstanceOf(CloudProvider::class)
+            ->and($infrastructure->cloudProvider->id)->toBe($cloudProvider->id);
+    });
 
-    /** @var Infrastructure $infrastructure */
-    $infrastructure = Infrastructure::factory()->create([
-        'region_id' => $region->id,
-    ]);
+test('belongs to region',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var Region $region */
+        $region = Region::factory()->create();
 
-    expect($infrastructure->region)
-        ->toBeInstanceOf(Region::class);
-});
+        /** @var Infrastructure $infrastructure */
+        $infrastructure = Infrastructure::factory()->create([
+            'region_id' => $region->id,
+        ]);
 
-test('has many kubernetes clusters', function (): void {
-    /** @var Infrastructure $infrastructure */
-    $infrastructure = Infrastructure::factory()->create();
+        expect($infrastructure->region)->toBeInstanceOf(Region::class)
+            ->and($infrastructure->region->id)->toBe($region->id);
+    });
 
-    expect($infrastructure->kubernetesClusters)->toBeEmpty();
-});
+test('has many kubernetes clusters',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var Infrastructure $infrastructure */
+        $infrastructure = Infrastructure::factory()->create();
 
-test('has many networks', function (): void {
-    /** @var Infrastructure $infrastructure */
-    $infrastructure = Infrastructure::factory()->create();
+        /** @var KubernetesCluster $cluster */
+        $cluster = KubernetesCluster::factory()->create([
+            'infrastructure_id' => $infrastructure->id,
+        ]);
 
-    expect($infrastructure->networks)->toBeEmpty();
-});
+        expect($infrastructure->kubernetesClusters)->toHaveCount(1)
+            ->and($infrastructure->kubernetesClusters->first())->toBeInstanceOf(KubernetesCluster::class)
+            ->and($infrastructure->kubernetesClusters->first()->id)->toBe($cluster->id);
+    });
 
-test('has many firewalls', function (): void {
-    /** @var Infrastructure $infrastructure */
-    $infrastructure = Infrastructure::factory()->create();
+test('has many networks',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var Infrastructure $infrastructure */
+        $infrastructure = Infrastructure::factory()->create();
 
-    expect($infrastructure->firewalls)->toBeEmpty();
-});
+        /** @var Network $network */
+        $network = Network::factory()->create([
+            'infrastructure_id' => $infrastructure->id,
+        ]);
 
-test('has many load balancers', function (): void {
-    /** @var Infrastructure $infrastructure */
-    $infrastructure = Infrastructure::factory()->create();
+        expect($infrastructure->networks)->toHaveCount(1)
+            ->and($infrastructure->networks->first())->toBeInstanceOf(Network::class)
+            ->and($infrastructure->networks->first()->id)->toBe($network->id);
+    });
 
-    expect($infrastructure->loadBalancers)->toBeEmpty();
-});
+test('has many firewalls',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var Infrastructure $infrastructure */
+        $infrastructure = Infrastructure::factory()->create();
 
-test('has many storages', function (): void {
-    /** @var Infrastructure $infrastructure */
-    $infrastructure = Infrastructure::factory()->create();
+        /** @var Firewall $firewall */
+        $firewall = Firewall::factory()->create([
+            'infrastructure_id' => $infrastructure->id,
+        ]);
 
-    expect($infrastructure->storages)->toBeEmpty();
-});
+        expect($infrastructure->firewalls)->toHaveCount(1)
+            ->and($infrastructure->firewalls->first())->toBeInstanceOf(Firewall::class)
+            ->and($infrastructure->firewalls->first()->id)->toBe($firewall->id);
+    });
 
-test('has many backups', function (): void {
-    /** @var Infrastructure $infrastructure */
-    $infrastructure = Infrastructure::factory()->create();
+test('has many load balancers',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var Infrastructure $infrastructure */
+        $infrastructure = Infrastructure::factory()->create();
 
-    expect($infrastructure->backups)->toBeEmpty();
-});
+        /** @var LoadBalancer $loadBalancer */
+        $loadBalancer = LoadBalancer::factory()->create([
+            'infrastructure_id' => $infrastructure->id,
+        ]);
 
-test('has many ssh keys', function (): void {
-    /** @var Infrastructure $infrastructure */
-    $infrastructure = Infrastructure::factory()->create();
+        expect($infrastructure->loadBalancers)->toHaveCount(1)
+            ->and($infrastructure->loadBalancers->first())->toBeInstanceOf(LoadBalancer::class)
+            ->and($infrastructure->loadBalancers->first()->id)->toBe($loadBalancer->id);
+    });
 
-    expect($infrastructure->sshKeys)->toBeEmpty();
-});
+test('has many storages',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var Infrastructure $infrastructure */
+        $infrastructure = Infrastructure::factory()->create();
+
+        /** @var Storage $storage */
+        $storage = Storage::factory()->create([
+            'infrastructure_id' => $infrastructure->id,
+        ]);
+
+        expect($infrastructure->storages)->toHaveCount(1)
+            ->and($infrastructure->storages->first())->toBeInstanceOf(Storage::class)
+            ->and($infrastructure->storages->first()->id)->toBe($storage->id);
+    });
+
+test('has many backups',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var Infrastructure $infrastructure */
+        $infrastructure = Infrastructure::factory()->create();
+
+        /** @var Backup $backup */
+        $backup = Backup::factory()->create([
+            'infrastructure_id' => $infrastructure->id,
+        ]);
+
+        expect($infrastructure->backups)->toHaveCount(1)
+            ->and($infrastructure->backups->first())->toBeInstanceOf(Backup::class)
+            ->and($infrastructure->backups->first()->id)->toBe($backup->id);
+    });
+
+test('has many ssh keys',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var Infrastructure $infrastructure */
+        $infrastructure = Infrastructure::factory()->create();
+
+        /** @var SshKey $sshKey */
+        $sshKey = SshKey::factory()->create([
+            'infrastructure_id' => $infrastructure->id,
+        ]);
+
+        expect($infrastructure->sshKeys)->toHaveCount(1)
+            ->and($infrastructure->sshKeys->first())->toBeInstanceOf(SshKey::class)
+            ->and($infrastructure->sshKeys->first()->id)->toBe($sshKey->id);
+    });
+
+test('casts attributes correctly',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var Infrastructure $infrastructure */
+        $infrastructure = Infrastructure::factory()->create([
+            'status' => InfrastructureStatus::Healthy,
+        ]);
+
+        expect($infrastructure->id)->toBeString()
+            ->and($infrastructure->created_at)->toBeInstanceOf(CarbonImmutable::class)
+            ->and($infrastructure->updated_at)->toBeInstanceOf(CarbonImmutable::class)
+            ->and($infrastructure->status)->toBe(InfrastructureStatus::Healthy);
+    });
+
+test('uses uuid for primary key',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var Infrastructure $infrastructure */
+        $infrastructure = Infrastructure::factory()->create();
+
+        expect($infrastructure->id)
+            ->toBeString()
+            ->toBeUuid();
+    });
+
+test('to array has all fields in correct order',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var Infrastructure $infrastructure */
+        $infrastructure = Infrastructure::factory()
+            ->create()
+            ->refresh();
+
+        expect(array_keys($infrastructure->toArray()))
+            ->toBe([
+                'id',
+                'created_at',
+                'updated_at',
+                'organization_id',
+                'cloud_provider_id',
+                'region_id',
+                'name',
+                'description',
+                'status',
+            ]);
+    });


### PR DESCRIPTION
## Summary

- Aligns CloudProviderTest and InfrastructureTest with `tests/CONTRIBUTING.md` conventions
- Adds mandatory tests: "creates model", "casts attributes correctly", "uses uuid for primary key"
- Reorders tests: creates model → relationships → casts → uuid → toArray (last)
- Renames toArray test to "to array has all fields in correct order"
- Adds `@throws Throwable` on closures that touch the database
- Adds `/** @var */` type hints on all factory variables
- CloudProviderTest: adds `use Illuminate\Support\Facades\DB` import, encryption asserted in both "casts attributes correctly" and dedicated "api token is encrypted" test
- InfrastructureTest: all 8 hasMany relationships now create related models and verify link + ID match
- Uses `create()->refresh()` instead of `create()->fresh()` in toArray tests

Closes #12

## Test plan

- [x] `php artisan test --compact tests/Unit/Models/{CloudProvider,Infrastructure}Test.php` — 23 tests, 62 assertions pass
- [x] `vendor/bin/pint --dirty --format agent` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)