### PR TITLE
feat: Server sync command and API endpoint

### DIFF
--- a/app/Actions/SyncServers.php
+++ b/app/Actions/SyncServers.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace App\Actions;
 
+use App\Data\SyncSummaryData;
 use App\Models\CloudProvider;
 use App\Models\Infrastructure;
-use App\Queries\InfrastructureQuery;
 use App\Queries\ServerQuery;
 use App\Services\CloudProviderFactory;
 
@@ -14,51 +14,63 @@ final readonly class SyncServers
 {
     public function __construct(
         private CloudProviderFactory $factory,
-        private InfrastructureQuery $infrastructureQuery,
         private ServerQuery $serverQuery,
     ) {}
 
-    public function handle(CloudProvider $provider): void
+    public function handle(CloudProvider $provider, Infrastructure $infrastructure): SyncSummaryData
     {
-        $infrastructure = ($this->infrastructureQuery)()->byProvider($provider)->first();
-
-        if (! $infrastructure) {
-            $infrastructure = Infrastructure::create([
-                'organization_id' => $provider->organization_id,
-                'cloud_provider_id' => $provider->id,
-                'name' => 'Default Infrastructure',
-                'description' => 'Auto-created infrastructure for synced servers',
-            ]);
-        }
-
         $serverService = $this->factory->makeServerService($provider->type, $provider->api_token);
         $remoteServers = $serverService->getAll();
 
         $remoteExternalIds = [];
+        $created = 0;
+        $updated = 0;
 
         foreach ($remoteServers as $serverData) {
             $externalId = (string) $serverData->externalId;
             $remoteExternalIds[] = $externalId;
 
-            $provider->servers()->updateOrCreate(
-                ['external_id' => $externalId],
-                [
-                    'organization_id' => $provider->organization_id,
-                    'infrastructure_id' => $infrastructure->id,
+            $existing = ($this->serverQuery)()
+                ->byProvider($provider)
+                ->byExternalId($externalId)
+                ->first();
+
+            if ($existing !== null) {
+                $existing->update([
                     'name' => $serverData->name,
                     'status' => $serverData->status,
                     'type' => $serverData->type,
                     'region' => $serverData->region,
                     'ipv4' => $serverData->ipv4,
                     'ipv6' => $serverData->ipv6,
-                ],
-            );
+                ]);
+                $updated++;
+            } else {
+                $provider->servers()->create([
+                    'organization_id' => $provider->organization_id,
+                    'infrastructure_id' => $infrastructure->id,
+                    'external_id' => $externalId,
+                    'name' => $serverData->name,
+                    'status' => $serverData->status,
+                    'type' => $serverData->type,
+                    'region' => $serverData->region,
+                    'ipv4' => $serverData->ipv4,
+                    'ipv6' => $serverData->ipv6,
+                ]);
+                $created++;
+            }
         }
 
-        ($this->serverQuery)()
+        $deleted = ($this->serverQuery)()
             ->byProvider($provider)
             ->builder()
             ->whereNotIn('external_id', $remoteExternalIds)
             ->delete();
+
+        return new SyncSummaryData(
+            created: $created,
+            updated: $updated,
+            deleted: $deleted,
+        );
     }
 }

--- a/app/Client/HttpServerClient.php
+++ b/app/Client/HttpServerClient.php
@@ -7,6 +7,7 @@ namespace App\Client;
 use App\Contracts\ServerClient;
 use App\Data\CreateServerData;
 use App\Data\ServerResourceData;
+use App\Data\SyncSummaryData;
 
 final readonly class HttpServerClient implements ServerClient
 {
@@ -48,5 +49,14 @@ final readonly class HttpServerClient implements ServerClient
     public function delete(string $id): void
     {
         $this->client->delete("/api/v1/servers/{$id}");
+    }
+
+    public function sync(string $cloudProviderId): SyncSummaryData
+    {
+        $response = $this->client->post('/api/v1/servers/sync', [
+            'cloud_provider_id' => $cloudProviderId,
+        ]);
+
+        return SyncSummaryData::fromArray($response->json('data'));
     }
 }

--- a/app/Client/InMemoryServerClient.php
+++ b/app/Client/InMemoryServerClient.php
@@ -8,6 +8,7 @@ use App\Contracts\ServerClient;
 use App\Data\ApiErrorData;
 use App\Data\CreateServerData;
 use App\Data\ServerResourceData;
+use App\Data\SyncSummaryData;
 use App\Enums\ApiErrorCode;
 use App\Exceptions\LarakubeApiException;
 
@@ -31,6 +32,10 @@ final class InMemoryServerClient implements ServerClient
     private bool $failShow = false;
 
     private bool $failDelete = false;
+
+    private ?SyncSummaryData $syncResponse = null;
+
+    private bool $failSync = false;
 
     public function setCreateResponse(ServerResourceData $data): void
     {
@@ -142,5 +147,27 @@ final class InMemoryServerClient implements ServerClient
 
         $this->deleteCalled = true;
         $this->deletedId = $id;
+    }
+
+    public function setSyncResponse(SyncSummaryData $data): void
+    {
+        $this->syncResponse = $data;
+    }
+
+    public function shouldFailSync(): void
+    {
+        $this->failSync = true;
+    }
+
+    public function sync(string $cloudProviderId): SyncSummaryData
+    {
+        if ($this->failSync) {
+            throw new LarakubeApiException(new ApiErrorData(
+                message: 'Failed to sync servers.',
+                code: ApiErrorCode::ValidationFailed,
+            ));
+        }
+
+        return $this->syncResponse ?? new SyncSummaryData(created: 0, updated: 0, deleted: 0);
     }
 }

--- a/app/Console/Commands/SyncServerCommand.php
+++ b/app/Console/Commands/SyncServerCommand.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Contracts\CloudProviderClient;
+use App\Contracts\ServerClient;
+use App\Enums\CloudProviderType;
+use App\Exceptions\LarakubeApiException;
+
+use function Laravel\Prompts\select;
+
+final class SyncServerCommand extends AuthenticatedCommand
+{
+    /**
+     * @var string
+     */
+    protected $signature = 'server:sync {--provider= : Cloud provider ID}';
+
+    /**
+     * @var string
+     */
+    protected $description = 'Sync servers from a cloud provider';
+
+    protected bool $requiresOrganization = true;
+
+    protected bool $requiresInfrastructure = true;
+
+    public function handleCommand(ServerClient $serverClient, CloudProviderClient $cloudProviderClient): int
+    {
+        try {
+            $providers = $cloudProviderClient->list();
+        } catch (LarakubeApiException $e) {
+            $this->components->error($e->getMessage());
+
+            return self::FAILURE;
+        }
+
+        if ($providers === []) {
+            $this->components->info('No cloud providers configured. Run [cloud-provider:add] first.');
+
+            return self::SUCCESS;
+        }
+
+        $providerOption = $this->option('provider');
+
+        if ($providerOption) {
+            $provider = null;
+            foreach ($providers as $p) {
+                if ($p->id === $providerOption) {
+                    $provider = $p;
+                    break;
+                }
+            }
+            if ($provider === null) {
+                $this->components->error('Provider not found.');
+
+                return self::FAILURE;
+            }
+            $providerId = $provider->id;
+        } else {
+            $choices = [];
+            foreach ($providers as $p) {
+                $choices[$p->id] = "{$p->name} (".CloudProviderType::from($p->type)->label().')';
+            }
+
+            $providerId = select(
+                label: 'Select a cloud provider',
+                options: $choices,
+            );
+        }
+
+        $this->components->info('Syncing servers...');
+
+        try {
+            $summary = $serverClient->sync($providerId);
+        } catch (LarakubeApiException $e) {
+            $this->components->error($e->getMessage());
+
+            return self::FAILURE;
+        }
+
+        $this->components->info("Sync complete: {$summary->created} created, {$summary->updated} updated, {$summary->deleted} deleted.");
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Contracts/ServerClient.php
+++ b/app/Contracts/ServerClient.php
@@ -6,6 +6,7 @@ namespace App\Contracts;
 
 use App\Data\CreateServerData;
 use App\Data\ServerResourceData;
+use App\Data\SyncSummaryData;
 use App\Exceptions\LarakubeApiException;
 
 interface ServerClient
@@ -31,4 +32,9 @@ interface ServerClient
      * @throws LarakubeApiException
      */
     public function delete(string $id): void;
+
+    /**
+     * @throws LarakubeApiException
+     */
+    public function sync(string $cloudProviderId): SyncSummaryData;
 }

--- a/app/Data/SyncSummaryData.php
+++ b/app/Data/SyncSummaryData.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Data;
+
+final readonly class SyncSummaryData
+{
+    public function __construct(
+        public int $created,
+        public int $updated,
+        public int $deleted,
+    ) {}
+
+    /**
+     * @param  array{created: int, updated: int, deleted: int}  $data
+     */
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            created: $data['created'],
+            updated: $data['updated'],
+            deleted: $data['deleted'],
+        );
+    }
+
+    /**
+     * @return array{created: int, updated: int, deleted: int}
+     */
+    public function toArray(): array
+    {
+        return [
+            'created' => $this->created,
+            'updated' => $this->updated,
+            'deleted' => $this->deleted,
+        ];
+    }
+}

--- a/app/Http/Controllers/Api/V1/ServerController.php
+++ b/app/Http/Controllers/Api/V1/ServerController.php
@@ -60,7 +60,7 @@ final class ServerController
             ], ApiErrorCode::ValidationFailed->httpStatus());
         }
 
-        return (new ServerResource($server))
+        return new ServerResource($server)
             ->response()
             ->setStatusCode(201);
     }

--- a/app/Http/Controllers/Api/V1/SyncServerController.php
+++ b/app/Http/Controllers/Api/V1/SyncServerController.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Actions\SyncServers;
+use App\Http\Requests\Api\V1\SyncServersRequest;
+use App\Queries\CloudProviderQuery;
+use Illuminate\Http\JsonResponse;
+
+final class SyncServerController
+{
+    public function store(
+        SyncServersRequest $request,
+        SyncServers $syncServers,
+        CloudProviderQuery $cloudProviderQuery,
+    ): JsonResponse {
+        $provider = ($cloudProviderQuery)()
+            ->byOrganization($request->organization)
+            ->builder()
+            ->findOrFail($request->validated('cloud_provider_id'));
+
+        $summary = $syncServers->handle($provider, $request->infrastructure);
+
+        return response()->json(['data' => $summary->toArray()]);
+    }
+}

--- a/app/Http/Requests/Api/V1/SyncServersRequest.php
+++ b/app/Http/Requests/Api/V1/SyncServersRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Api\V1;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+final class SyncServersRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, array<int, string>>
+     */
+    public function rules(): array
+    {
+        return [
+            'cloud_provider_id' => ['required', 'string', 'exists:cloud_providers,id'],
+        ];
+    }
+}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -18,7 +18,6 @@
         </include>
         <exclude>
             <file>app/Providers/TelescopeServiceProvider.php</file>
-            <file>app/Actions/SyncServers.php</file>
         </exclude>
     </source>
     <php>

--- a/routes/api.php
+++ b/routes/api.php
@@ -8,6 +8,7 @@ use App\Http\Controllers\Api\V1\InfrastructureController;
 use App\Http\Controllers\Api\V1\OrganizationController;
 use App\Http\Controllers\Api\V1\RegisterController;
 use App\Http\Controllers\Api\V1\ServerController;
+use App\Http\Controllers\Api\V1\SyncServerController;
 use App\Http\Middleware\ResolveInfrastructure;
 use App\Http\Middleware\ResolveOrganization;
 use Illuminate\Support\Facades\Route;
@@ -40,9 +41,13 @@ Route::prefix('v1')->as('api.v1.')->group(function (): void {
                 ->only(['index', 'show', 'destroy'])
                 ->names('servers');
 
-            Route::post('servers', [ServerController::class, 'store'])
-                ->middleware(ResolveInfrastructure::class)
-                ->name('servers.store');
+            Route::middleware(ResolveInfrastructure::class)->group(function (): void {
+                Route::post('servers', [ServerController::class, 'store'])
+                    ->name('servers.store');
+
+                Route::post('servers/sync', [SyncServerController::class, 'store'])
+                    ->name('servers.sync');
+            });
         });
     });
 });

--- a/tests/Feature/Api/V1/ServerControllerTest.php
+++ b/tests/Feature/Api/V1/ServerControllerTest.php
@@ -202,6 +202,60 @@ test('destroy fails when cloud provider api fails',
             ->assertJsonPath('code', 'validation_failed');
     });
 
+test('sync returns summary of changes',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        $this->serverService->addServer(new ServerData(
+            externalId: '100',
+            name: 'web-1',
+            status: ServerStatus::Running,
+            type: 'cx11',
+            region: 'fsn1',
+            ipv4: '1.2.3.4',
+        ));
+
+        $response = $this->actingAs($this->user, 'sanctum')
+            ->withHeaders([
+                'X-Organization-Id' => $this->organization->id,
+                'X-Infrastructure-Id' => $this->infrastructure->id,
+            ])
+            ->postJson(route('api.v1.servers.sync'), [
+                'cloud_provider_id' => $this->provider->id,
+            ]);
+
+        $response->assertOk()
+            ->assertJsonStructure(['data' => ['created', 'updated', 'deleted']])
+            ->assertJsonPath('data.created', 1)
+            ->assertJsonPath('data.updated', 0)
+            ->assertJsonPath('data.deleted', 0);
+    });
+
+test('sync validates cloud_provider_id',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        $response = $this->actingAs($this->user, 'sanctum')
+            ->withHeaders([
+                'X-Organization-Id' => $this->organization->id,
+                'X-Infrastructure-Id' => $this->infrastructure->id,
+            ])
+            ->postJson(route('api.v1.servers.sync'), []);
+
+        $response->assertUnprocessable()
+            ->assertJsonValidationErrors(['cloud_provider_id']);
+    });
+
+test('sync requires authentication and headers',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        $this->postJson(route('api.v1.servers.sync'))->assertUnauthorized();
+    });
+
 test('all endpoints require authentication',
     /**
      * @throws Throwable

--- a/tests/Feature/Commands/SyncServerCommandTest.php
+++ b/tests/Feature/Commands/SyncServerCommandTest.php
@@ -1,0 +1,202 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\LoginUser;
+use App\Client\InMemoryCloudProviderClient;
+use App\Client\InMemoryServerClient;
+use App\Console\Services\SessionManager;
+use App\Contracts\CloudProviderClient;
+use App\Contracts\ServerClient;
+use App\Data\CloudProviderData;
+use App\Data\SessionInfrastructureData;
+use App\Data\SessionOrganizationData;
+use App\Data\SyncSummaryData;
+use App\Models\Infrastructure;
+use App\Models\Organization;
+use App\Models\User;
+
+beforeEach(function (): void {
+    $this->app->singleton(SessionManager::class);
+    $this->cloudProviderClient = new InMemoryCloudProviderClient();
+    $this->app->instance(CloudProviderClient::class, $this->cloudProviderClient);
+    $this->serverClient = new InMemoryServerClient();
+    $this->app->instance(ServerClient::class, $this->serverClient);
+});
+
+test('sync server command displays summary',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var User $user */
+        $user = User::factory()->create(['email' => 'john@example.com', 'password' => 'password123']);
+        /** @var Organization $organization */
+        $organization = Organization::factory()->create();
+        $organization->users()->attach($user, ['role' => 'owner']);
+        /** @var Infrastructure $infrastructure */
+        $infrastructure = Infrastructure::factory()->create(['organization_id' => $organization->id]);
+
+        $userData = app(LoginUser::class)->handle('john@example.com', 'password123');
+        $session = app(SessionManager::class);
+        $session->setUser($userData);
+        $session->setOrganization(new SessionOrganizationData(id: $organization->id, name: $organization->name, slug: $organization->slug));
+        $session->setInfrastructure(new SessionInfrastructureData(id: $infrastructure->id, name: $infrastructure->name));
+
+        $this->cloudProviderClient->setListResponse([
+            new CloudProviderData(id: 'cp-1', name: 'Hetzner Prod', type: 'hetzner', isVerified: true),
+        ]);
+
+        $this->serverClient->setSyncResponse(new SyncSummaryData(created: 3, updated: 1, deleted: 2));
+
+        $this->artisan('server:sync')
+            ->expectsQuestion('Select a cloud provider', 'cp-1')
+            ->expectsOutputToContain('3 created, 1 updated, 2 deleted')
+            ->assertSuccessful();
+    });
+
+test('sync server command works with provider flag',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var User $user */
+        $user = User::factory()->create(['email' => 'john@example.com', 'password' => 'password123']);
+        /** @var Organization $organization */
+        $organization = Organization::factory()->create();
+        $organization->users()->attach($user, ['role' => 'owner']);
+        /** @var Infrastructure $infrastructure */
+        $infrastructure = Infrastructure::factory()->create(['organization_id' => $organization->id]);
+
+        $userData = app(LoginUser::class)->handle('john@example.com', 'password123');
+        $session = app(SessionManager::class);
+        $session->setUser($userData);
+        $session->setOrganization(new SessionOrganizationData(id: $organization->id, name: $organization->name, slug: $organization->slug));
+        $session->setInfrastructure(new SessionInfrastructureData(id: $infrastructure->id, name: $infrastructure->name));
+
+        $this->cloudProviderClient->setListResponse([
+            new CloudProviderData(id: 'cp-1', name: 'Hetzner Prod', type: 'hetzner', isVerified: true),
+        ]);
+
+        $this->artisan('server:sync --provider=cp-1')
+            ->expectsOutputToContain('Sync complete')
+            ->assertSuccessful();
+    });
+
+test('sync server command fails when sync api errors',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var User $user */
+        $user = User::factory()->create(['email' => 'john@example.com', 'password' => 'password123']);
+        /** @var Organization $organization */
+        $organization = Organization::factory()->create();
+        $organization->users()->attach($user, ['role' => 'owner']);
+        /** @var Infrastructure $infrastructure */
+        $infrastructure = Infrastructure::factory()->create(['organization_id' => $organization->id]);
+
+        $userData = app(LoginUser::class)->handle('john@example.com', 'password123');
+        $session = app(SessionManager::class);
+        $session->setUser($userData);
+        $session->setOrganization(new SessionOrganizationData(id: $organization->id, name: $organization->name, slug: $organization->slug));
+        $session->setInfrastructure(new SessionInfrastructureData(id: $infrastructure->id, name: $infrastructure->name));
+
+        $this->cloudProviderClient->setListResponse([
+            new CloudProviderData(id: 'cp-1', name: 'Hetzner Prod', type: 'hetzner', isVerified: true),
+        ]);
+        $this->serverClient->shouldFailSync();
+
+        $this->artisan('server:sync')
+            ->expectsQuestion('Select a cloud provider', 'cp-1')
+            ->expectsOutputToContain('Failed to sync servers.')
+            ->assertFailed();
+    });
+
+test('sync server command fails on list providers error',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var User $user */
+        $user = User::factory()->create(['email' => 'john@example.com', 'password' => 'password123']);
+        /** @var Organization $organization */
+        $organization = Organization::factory()->create();
+        $organization->users()->attach($user, ['role' => 'owner']);
+        /** @var Infrastructure $infrastructure */
+        $infrastructure = Infrastructure::factory()->create(['organization_id' => $organization->id]);
+
+        $userData = app(LoginUser::class)->handle('john@example.com', 'password123');
+        $session = app(SessionManager::class);
+        $session->setUser($userData);
+        $session->setOrganization(new SessionOrganizationData(id: $organization->id, name: $organization->name, slug: $organization->slug));
+        $session->setInfrastructure(new SessionInfrastructureData(id: $infrastructure->id, name: $infrastructure->name));
+
+        $this->cloudProviderClient->shouldFailList();
+
+        $this->artisan('server:sync')
+            ->expectsOutputToContain('Unauthenticated.')
+            ->assertFailed();
+    });
+
+test('sync server command shows message when no providers',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var User $user */
+        $user = User::factory()->create(['email' => 'john@example.com', 'password' => 'password123']);
+        /** @var Organization $organization */
+        $organization = Organization::factory()->create();
+        $organization->users()->attach($user, ['role' => 'owner']);
+        /** @var Infrastructure $infrastructure */
+        $infrastructure = Infrastructure::factory()->create(['organization_id' => $organization->id]);
+
+        $userData = app(LoginUser::class)->handle('john@example.com', 'password123');
+        $session = app(SessionManager::class);
+        $session->setUser($userData);
+        $session->setOrganization(new SessionOrganizationData(id: $organization->id, name: $organization->name, slug: $organization->slug));
+        $session->setInfrastructure(new SessionInfrastructureData(id: $infrastructure->id, name: $infrastructure->name));
+
+        $this->artisan('server:sync')
+            ->expectsOutputToContain('No cloud providers configured')
+            ->assertSuccessful();
+    });
+
+test('sync server command fails when not authenticated',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        $this->artisan('server:sync')
+            ->expectsOutputToContain('You are not logged in')
+            ->assertFailed();
+    });
+
+test('sync server command fails with invalid provider flag',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var User $user */
+        $user = User::factory()->create(['email' => 'john@example.com', 'password' => 'password123']);
+        /** @var Organization $organization */
+        $organization = Organization::factory()->create();
+        $organization->users()->attach($user, ['role' => 'owner']);
+        /** @var Infrastructure $infrastructure */
+        $infrastructure = Infrastructure::factory()->create(['organization_id' => $organization->id]);
+
+        $userData = app(LoginUser::class)->handle('john@example.com', 'password123');
+        $session = app(SessionManager::class);
+        $session->setUser($userData);
+        $session->setOrganization(new SessionOrganizationData(id: $organization->id, name: $organization->name, slug: $organization->slug));
+        $session->setInfrastructure(new SessionInfrastructureData(id: $infrastructure->id, name: $infrastructure->name));
+
+        $this->cloudProviderClient->setListResponse([
+            new CloudProviderData(id: 'cp-1', name: 'Hetzner Prod', type: 'hetzner', isVerified: true),
+        ]);
+
+        $this->artisan('server:sync --provider=nonexistent')
+            ->expectsOutputToContain('Provider not found.')
+            ->assertFailed();
+    });

--- a/tests/Unit/Actions/SyncServersTest.php
+++ b/tests/Unit/Actions/SyncServersTest.php
@@ -1,0 +1,190 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\SyncServers;
+use App\Data\ServerData;
+use App\Data\SyncSummaryData;
+use App\Enums\ServerStatus;
+use App\Models\CloudProvider;
+use App\Models\Infrastructure;
+use App\Models\Organization;
+use App\Models\Server;
+
+beforeEach(function (): void {
+    $this->serverService = useInMemoryHetznerServerService();
+    bindInMemoryHetznerFactory(serverService: $this->serverService);
+
+    $this->organization = Organization::factory()->create();
+    $this->provider = CloudProvider::factory()->hetzner()->create([
+        'organization_id' => $this->organization->id,
+    ]);
+    $this->infrastructure = Infrastructure::factory()->create([
+        'organization_id' => $this->organization->id,
+        'cloud_provider_id' => $this->provider->id,
+    ]);
+});
+
+test('creates new servers from remote',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        $this->serverService->addServer(new ServerData(
+            externalId: '100',
+            name: 'web-1',
+            status: ServerStatus::Running,
+            type: 'cx11',
+            region: 'fsn1',
+            ipv4: '1.2.3.4',
+        ));
+
+        $summary = app(SyncServers::class)->handle($this->provider, $this->infrastructure);
+
+        expect($summary)
+            ->toBeInstanceOf(SyncSummaryData::class)
+            ->created->toBe(1)
+            ->updated->toBe(0)
+            ->deleted->toBe(0);
+
+        $this->assertDatabaseHas('servers', [
+            'external_id' => '100',
+            'name' => 'web-1',
+            'infrastructure_id' => $this->infrastructure->id,
+        ]);
+    });
+
+test('updates existing servers from remote',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        Server::factory()->create([
+            'organization_id' => $this->organization->id,
+            'cloud_provider_id' => $this->provider->id,
+            'infrastructure_id' => $this->infrastructure->id,
+            'external_id' => '100',
+            'name' => 'web-1',
+            'status' => ServerStatus::Off,
+            'ipv4' => '0.0.0.0',
+        ]);
+
+        $this->serverService->addServer(new ServerData(
+            externalId: '100',
+            name: 'web-1',
+            status: ServerStatus::Running,
+            type: 'cx11',
+            region: 'fsn1',
+            ipv4: '1.2.3.4',
+        ));
+
+        $summary = app(SyncServers::class)->handle($this->provider, $this->infrastructure);
+
+        expect($summary)
+            ->created->toBe(0)
+            ->updated->toBe(1)
+            ->deleted->toBe(0);
+
+        $this->assertDatabaseHas('servers', [
+            'external_id' => '100',
+            'status' => 'running',
+            'ipv4' => '1.2.3.4',
+        ]);
+    });
+
+test('preserves infrastructure assignment on existing servers',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        $otherInfra = Infrastructure::factory()->create([
+            'organization_id' => $this->organization->id,
+            'cloud_provider_id' => $this->provider->id,
+            'name' => 'Other Infra',
+        ]);
+
+        Server::factory()->create([
+            'organization_id' => $this->organization->id,
+            'cloud_provider_id' => $this->provider->id,
+            'infrastructure_id' => $otherInfra->id,
+            'external_id' => '100',
+            'name' => 'web-1',
+        ]);
+
+        $this->serverService->addServer(new ServerData(
+            externalId: '100',
+            name: 'web-1',
+            status: ServerStatus::Running,
+            type: 'cx11',
+            region: 'fsn1',
+        ));
+
+        app(SyncServers::class)->handle($this->provider, $this->infrastructure);
+
+        $this->assertDatabaseHas('servers', [
+            'external_id' => '100',
+            'infrastructure_id' => $otherInfra->id,
+        ]);
+    });
+
+test('deletes servers not present on remote',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        Server::factory()->create([
+            'organization_id' => $this->organization->id,
+            'cloud_provider_id' => $this->provider->id,
+            'infrastructure_id' => $this->infrastructure->id,
+            'external_id' => '999',
+            'name' => 'deleted-server',
+        ]);
+
+        $summary = app(SyncServers::class)->handle($this->provider, $this->infrastructure);
+
+        expect($summary)
+            ->created->toBe(0)
+            ->updated->toBe(0)
+            ->deleted->toBe(1);
+
+        $this->assertDatabaseMissing('servers', ['external_id' => '999']);
+    });
+
+test('returns correct counts for mixed operations',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        Server::factory()->create([
+            'organization_id' => $this->organization->id,
+            'cloud_provider_id' => $this->provider->id,
+            'infrastructure_id' => $this->infrastructure->id,
+            'external_id' => '100',
+            'name' => 'existing',
+            'status' => ServerStatus::Off,
+        ]);
+
+        Server::factory()->create([
+            'organization_id' => $this->organization->id,
+            'cloud_provider_id' => $this->provider->id,
+            'infrastructure_id' => $this->infrastructure->id,
+            'external_id' => '999',
+            'name' => 'to-delete',
+        ]);
+
+        $this->serverService->addServer(new ServerData(
+            externalId: '100', name: 'existing', status: ServerStatus::Running,
+            type: 'cx11', region: 'fsn1',
+        ));
+        $this->serverService->addServer(new ServerData(
+            externalId: '200', name: 'new-server', status: ServerStatus::Running,
+            type: 'cx11', region: 'fsn1',
+        ));
+
+        $summary = app(SyncServers::class)->handle($this->provider, $this->infrastructure);
+
+        expect($summary)
+            ->created->toBe(1)
+            ->updated->toBe(1)
+            ->deleted->toBe(1);
+    });

--- a/tests/Unit/Client/HttpServerClientTest.php
+++ b/tests/Unit/Client/HttpServerClientTest.php
@@ -91,3 +91,22 @@ test('delete sends delete request',
         Http::assertSent(fn ($request): bool => $request->method() === 'DELETE'
             && str_contains((string) $request->url(), '/api/v1/servers/srv-1'));
     });
+
+test('sync returns sync summary data',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        Http::fake([
+            '*/api/v1/servers/sync' => Http::response([
+                'data' => ['created' => 3, 'updated' => 1, 'deleted' => 2],
+            ]),
+        ]);
+
+        $result = $this->client->sync('cp-1');
+
+        expect($result)
+            ->created->toBe(3)
+            ->updated->toBe(1)
+            ->deleted->toBe(2);
+    });

--- a/tests/Unit/Data/SyncSummaryDataTest.php
+++ b/tests/Unit/Data/SyncSummaryDataTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Data\SyncSummaryData;
+
+test('constructor sets properties', function (): void {
+    $data = new SyncSummaryData(created: 3, updated: 1, deleted: 2);
+
+    expect($data)
+        ->created->toBe(3)
+        ->updated->toBe(1)
+        ->deleted->toBe(2);
+});
+
+test('fromArray and toArray round-trip', function (): void {
+    $original = ['created' => 3, 'updated' => 1, 'deleted' => 2];
+
+    $data = SyncSummaryData::fromArray($original);
+
+    expect($data->toArray())->toBe($original);
+});


### PR DESCRIPTION
## Summary

- Adds `POST /api/v1/servers/sync` endpoint via dedicated `SyncServerController` (resource controller convention)
- Refactors `SyncServers` action: accepts `Infrastructure` parameter (no auto-create), returns `SyncSummaryData`, preserves existing infrastructure assignments on re-sync
- Adds `SyncSummaryData` DTO with created/updated/deleted counts
- Extends `ServerClient` contract with `sync()` method, implemented in `HttpServerClient` and `InMemoryServerClient`
- Adds new `server:sync` CLI command with provider selection and summary display
- Removes `SyncServers` from phpunit.xml coverage exclusion

Closes #25

## Test plan

- [x] 497 tests passing (1157 assertions)
- [x] 100% code coverage
- [x] Pint clean
- [x] SyncServers action tests: create, update, delete, preserve infra, mixed counts
- [x] API endpoint tests: sync summary response, validation, auth
- [x] HTTP/InMemory client sync tests
- [x] Command tests: summary display, provider flag, error paths
- [x] SyncSummaryData DTO round-trip tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)