### PR TITLE
feat: MultipassService + MultipassServerService with injectable Process

### DIFF
--- a/app/Services/CloudProviderFactory.php
+++ b/app/Services/CloudProviderFactory.php
@@ -7,7 +7,6 @@ namespace App\Services;
 use App\Contracts\CloudProviderService;
 use App\Contracts\ServerService;
 use App\Enums\CloudProviderType;
-use RuntimeException;
 
 class CloudProviderFactory
 {
@@ -16,7 +15,7 @@ class CloudProviderFactory
         return match ($type) {
             CloudProviderType::Hetzner => new HetznerServerService($token ?? ''),
             CloudProviderType::DigitalOcean => new DigitalOceanServerService($token ?? ''),
-            CloudProviderType::Multipass => throw new RuntimeException('Multipass server service not yet implemented.'),
+            CloudProviderType::Multipass => new MultipassServerService(),
         };
     }
 
@@ -25,7 +24,7 @@ class CloudProviderFactory
         return match ($type) {
             CloudProviderType::Hetzner => new HetznerService($token ?? ''),
             CloudProviderType::DigitalOcean => new DigitalOceanService($token ?? ''),
-            CloudProviderType::Multipass => throw new RuntimeException('Multipass validation service not yet implemented.'),
+            CloudProviderType::Multipass => new MultipassService(),
         };
     }
 }

--- a/app/Services/InMemory/InMemoryMultipassFactory.php
+++ b/app/Services/InMemory/InMemoryMultipassFactory.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\InMemory;
+
+use App\Contracts\CloudProviderService;
+use App\Contracts\ServerService;
+use App\Enums\CloudProviderType;
+use App\Services\CloudProviderFactory;
+
+final class InMemoryMultipassFactory extends CloudProviderFactory
+{
+    public function __construct(
+        private readonly ?InMemoryMultipassService $validationService = null,
+        private readonly ?InMemoryMultipassServerService $serverService = null,
+    ) {}
+
+    public function makeServerService(CloudProviderType $type, ?string $token = null): ServerService
+    {
+        if ($type === CloudProviderType::Multipass && $this->serverService) {
+            return $this->serverService;
+        }
+
+        return parent::makeServerService($type, $token);
+    }
+
+    public function makeForValidation(CloudProviderType $type, ?string $token = null): CloudProviderService
+    {
+        if ($type === CloudProviderType::Multipass && $this->validationService) {
+            return $this->validationService;
+        }
+
+        return parent::makeForValidation($type, $token);
+    }
+}

--- a/app/Services/InMemory/InMemoryMultipassServerService.php
+++ b/app/Services/InMemory/InMemoryMultipassServerService.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\InMemory;
+
+use App\Contracts\ServerService;
+use App\Data\CreateServerData;
+use App\Data\ServerData;
+use App\Enums\ServerStatus;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
+use RuntimeException;
+
+final class InMemoryMultipassServerService implements ServerService
+{
+    /** @var Collection<int, ServerData> */
+    private readonly Collection $servers;
+
+    /** @var array<string, bool> */
+    private array $deletedServers = [];
+
+    private bool $shouldFailCreate = false;
+
+    private bool $shouldFailDelete = false;
+
+    public function __construct()
+    {
+        $this->servers = collect([]);
+    }
+
+    public function addServer(ServerData $server): self
+    {
+        $this->servers->push($server);
+
+        return $this;
+    }
+
+    public function shouldFailCreate(bool $fail = true): self
+    {
+        $this->shouldFailCreate = $fail;
+
+        return $this;
+    }
+
+    public function shouldFailDelete(bool $fail = true): self
+    {
+        $this->shouldFailDelete = $fail;
+
+        return $this;
+    }
+
+    public function getAll(): Collection
+    {
+        return $this->servers->filter(
+            fn (ServerData $server): bool => ! isset($this->deletedServers[(string) $server->externalId])
+        );
+    }
+
+    public function create(CreateServerData $data): ServerData
+    {
+        if ($this->shouldFailCreate) {
+            throw new RuntimeException('Failed to create Multipass VM.');
+        }
+
+        $name = $data->name.'-'.Str::random(6);
+
+        $serverData = new ServerData(
+            externalId: $name,
+            name: $name,
+            status: ServerStatus::Running,
+            type: 'custom',
+            region: 'local',
+            ipv4: '192.168.64.'.random_int(2, 254),
+        );
+
+        $this->servers->push($serverData);
+
+        return $serverData;
+    }
+
+    public function find(string $name): ?ServerData
+    {
+        return $this->servers->first(
+            fn (ServerData $server): bool => $server->name === $name
+                && ! isset($this->deletedServers[(string) $server->externalId])
+        );
+    }
+
+    public function destroy(int|string $externalId): bool
+    {
+        if ($this->shouldFailDelete) {
+            return false;
+        }
+
+        $server = $this->servers->first(
+            fn (ServerData $server): bool => (string) $server->externalId === (string) $externalId
+        );
+
+        if ($server === null) {
+            return false;
+        }
+
+        $this->deletedServers[(string) $externalId] = true;
+
+        return true;
+    }
+}

--- a/app/Services/InMemory/InMemoryMultipassService.php
+++ b/app/Services/InMemory/InMemoryMultipassService.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\InMemory;
+
+use App\Contracts\CloudProviderService;
+
+final class InMemoryMultipassService implements CloudProviderService
+{
+    private bool $shouldValidate = true;
+
+    public function setValidationResult(bool $valid): self
+    {
+        $this->shouldValidate = $valid;
+
+        return $this;
+    }
+
+    public function validateToken(): bool
+    {
+        return $this->shouldValidate;
+    }
+}

--- a/app/Services/MultipassServerService.php
+++ b/app/Services/MultipassServerService.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Contracts\ServerService;
+use App\Data\CreateServerData;
+use App\Data\ServerData;
+use App\Enums\ServerStatus;
+use Closure;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
+use RuntimeException;
+use Symfony\Component\Process\Process;
+
+final readonly class MultipassServerService implements ServerService
+{
+    /** @var Closure(list<string>): Process */
+    private Closure $processFactory;
+
+    /**
+     * @param  Closure(list<string>): Process|null  $processFactory
+     */
+    public function __construct(?Closure $processFactory = null)
+    {
+        $this->processFactory = $processFactory ?? fn (array $command): Process => new Process($command);
+    }
+
+    public function getAll(): Collection
+    {
+        $process = ($this->processFactory)(['multipass', 'list', '--format', 'json']);
+        $process->run();
+
+        if (! $process->isSuccessful()) {
+            throw new RuntimeException('Failed to list Multipass VMs: '.$process->getErrorOutput());
+        }
+
+        $data = json_decode($process->getOutput(), true);
+        $instances = $data['list'] ?? [];
+
+        return collect($instances)->map(fn (array $instance): ServerData => $this->mapInstanceData($instance));
+    }
+
+    public function create(CreateServerData $data): ServerData
+    {
+        $name = $data->name.'-'.Str::random(6);
+
+        $command = ['multipass', 'launch', $data->image, '--name', $name];
+
+        if ($data->cpus !== null) {
+            $command[] = '--cpus';
+            $command[] = (string) $data->cpus;
+        }
+
+        if ($data->memory !== null) {
+            $command[] = '--memory';
+            $command[] = $data->memory;
+        }
+
+        if ($data->disk !== null) {
+            $command[] = '--disk';
+            $command[] = $data->disk;
+        }
+
+        $process = ($this->processFactory)($command);
+        $process->setTimeout(300);
+        $process->run();
+
+        if (! $process->isSuccessful()) {
+            throw new RuntimeException('Failed to create Multipass VM: '.$process->getErrorOutput());
+        }
+
+        $info = $this->getInstanceInfo($name);
+
+        return $this->mapInstanceData($info);
+    }
+
+    public function find(string $name): ?ServerData
+    {
+        $info = $this->getInstanceInfo($name);
+
+        if ($info === null) {
+            return null;
+        }
+
+        return $this->mapInstanceData($info);
+    }
+
+    public function destroy(int|string $externalId): bool
+    {
+        $delete = ($this->processFactory)(['multipass', 'delete', (string) $externalId]);
+        $delete->run();
+
+        if (! $delete->isSuccessful()) {
+            return false;
+        }
+
+        $purge = ($this->processFactory)(['multipass', 'purge']);
+        $purge->run();
+
+        return $purge->isSuccessful();
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function getInstanceInfo(string $name): ?array
+    {
+        $process = ($this->processFactory)(['multipass', 'info', $name, '--format', 'json']);
+        $process->run();
+
+        if (! $process->isSuccessful()) {
+            return null;
+        }
+
+        $data = json_decode($process->getOutput(), true);
+        $instances = $data['info'] ?? [];
+
+        if (! isset($instances[$name])) {
+            return null;
+        }
+
+        $instance = $instances[$name];
+        $instance['name'] = $name;
+
+        return $instance;
+    }
+
+    /**
+     * @param  array<string, mixed>  $instance
+     */
+    private function mapInstanceData(array $instance): ServerData
+    {
+        $ipv4 = $instance['ipv4'][0] ?? $instance['ipv4'] ?? null;
+
+        return new ServerData(
+            externalId: $instance['name'],
+            name: $instance['name'],
+            status: ServerStatus::fromMultipass($instance['state'] ?? 'Unknown'),
+            type: 'custom',
+            region: 'local',
+            ipv4: is_array($ipv4) ? null : $ipv4,
+        );
+    }
+}

--- a/app/Services/MultipassService.php
+++ b/app/Services/MultipassService.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Contracts\CloudProviderService;
+use Closure;
+use Symfony\Component\Process\Process;
+
+final readonly class MultipassService implements CloudProviderService
+{
+    /** @var Closure(list<string>): Process */
+    private Closure $processFactory;
+
+    /**
+     * @param  Closure(list<string>): Process|null  $processFactory
+     */
+    public function __construct(?Closure $processFactory = null)
+    {
+        $this->processFactory = $processFactory ?? fn (array $command): Process => new Process($command);
+    }
+
+    public function validateToken(): bool
+    {
+        $process = ($this->processFactory)(['multipass', 'version']);
+        $process->run();
+
+        return $process->isSuccessful();
+    }
+}

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -148,3 +148,42 @@ function bindInMemoryDigitalOceanFactory(
 
     app()->instance(App\Services\CloudProviderFactory::class, $factory);
 }
+
+/**
+ * Use InMemory MultipassService for validation testing.
+ *
+ * @param  bool|null  $isValid  Set validation result (true=valid, false=invalid, null=no override)
+ */
+function useInMemoryMultipassService(?bool $isValid = null): App\Services\InMemory\InMemoryMultipassService
+{
+    $service = new App\Services\InMemory\InMemoryMultipassService();
+
+    if ($isValid !== null) {
+        $service->setValidationResult($isValid);
+    }
+
+    return $service;
+}
+
+/**
+ * Use InMemory MultipassServerService for server operations testing.
+ */
+function useInMemoryMultipassServerService(): App\Services\InMemory\InMemoryMultipassServerService
+{
+    return new App\Services\InMemory\InMemoryMultipassServerService();
+}
+
+/**
+ * Bind InMemory Multipass services to CloudProviderFactory.
+ *
+ * @param  App\Services\InMemory\InMemoryMultipassService|null  $validationService  Service for validation
+ * @param  App\Services\InMemory\InMemoryMultipassServerService|null  $serverService  Service for server operations
+ */
+function bindInMemoryMultipassFactory(
+    ?App\Services\InMemory\InMemoryMultipassService $validationService = null,
+    ?App\Services\InMemory\InMemoryMultipassServerService $serverService = null
+): void {
+    $factory = new App\Services\InMemory\InMemoryMultipassFactory($validationService, $serverService);
+
+    app()->instance(App\Services\CloudProviderFactory::class, $factory);
+}

--- a/tests/Unit/Services/InMemory/InMemoryMultipassFactoryTest.php
+++ b/tests/Unit/Services/InMemory/InMemoryMultipassFactoryTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\CloudProviderType;
+use App\Services\InMemory\InMemoryMultipassServerService;
+use App\Services\InMemory\InMemoryMultipassService;
+
+test('factory returns in-memory multipass validation service', function (): void {
+    $validationService = useInMemoryMultipassService(true);
+    bindInMemoryMultipassFactory($validationService);
+
+    $factory = app(App\Services\CloudProviderFactory::class);
+    $service = $factory->makeForValidation(CloudProviderType::Multipass);
+
+    expect($service)
+        ->toBeInstanceOf(InMemoryMultipassService::class)
+        ->and($service->validateToken())->toBeTrue();
+});
+
+test('factory returns in-memory multipass server service', function (): void {
+    $serverService = useInMemoryMultipassServerService();
+    bindInMemoryMultipassFactory(serverService: $serverService);
+
+    $factory = app(App\Services\CloudProviderFactory::class);
+    $service = $factory->makeServerService(CloudProviderType::Multipass);
+
+    expect($service)->toBeInstanceOf(InMemoryMultipassServerService::class);
+});
+
+test('factory falls back to parent for non-multipass server service', function (): void {
+    bindInMemoryMultipassFactory();
+
+    $factory = app(App\Services\CloudProviderFactory::class);
+    $service = $factory->makeServerService(CloudProviderType::Hetzner, 'token');
+
+    expect($service)->toBeInstanceOf(App\Services\HetznerServerService::class);
+});
+
+test('factory falls back to parent for non-multipass validation service', function (): void {
+    bindInMemoryMultipassFactory();
+
+    $factory = app(App\Services\CloudProviderFactory::class);
+    $service = $factory->makeForValidation(CloudProviderType::Hetzner, 'token');
+
+    expect($service)->toBeInstanceOf(App\Services\HetznerService::class);
+});

--- a/tests/Unit/Services/InMemory/InMemoryMultipassServerServiceTest.php
+++ b/tests/Unit/Services/InMemory/InMemoryMultipassServerServiceTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Data\CreateServerData;
+use App\Data\ServerData;
+use App\Enums\ServerStatus;
+use App\Services\InMemory\InMemoryMultipassServerService;
+
+test('get all returns servers', function (): void {
+    $service = new InMemoryMultipassServerService();
+    $service->addServer(new ServerData(
+        externalId: 'web-1-abc123',
+        name: 'web-1-abc123',
+        status: ServerStatus::Running,
+        type: 'custom',
+        region: 'local',
+        ipv4: '192.168.64.2',
+    ));
+
+    $servers = $service->getAll();
+
+    expect($servers)->toHaveCount(1)
+        ->and($servers[0]->name)->toBe('web-1-abc123');
+});
+
+test('create returns server data with unique suffix', function (): void {
+    $service = new InMemoryMultipassServerService();
+
+    $server = $service->create(new CreateServerData(
+        name: 'web-1',
+        type: 'custom',
+        image: 'noble',
+        region: 'local',
+        infrastructure_id: 'infra-1',
+        cpus: 2,
+        memory: '2G',
+        disk: '20G',
+    ));
+
+    expect($server->name)->toStartWith('web-1-')
+        ->and($server->name)->not->toBe('web-1')
+        ->and($server->status)->toBe(ServerStatus::Running)
+        ->and($server->region)->toBe('local');
+});
+
+test('create fails when configured to fail', function (): void {
+    $service = new InMemoryMultipassServerService();
+    $service->shouldFailCreate(true);
+
+    $service->create(new CreateServerData(
+        name: 'web-1',
+        type: 'custom',
+        image: 'noble',
+        region: 'local',
+        infrastructure_id: 'infra-1',
+    ));
+})->throws(RuntimeException::class);
+
+test('find returns server by name', function (): void {
+    $service = new InMemoryMultipassServerService();
+    $service->addServer(new ServerData(
+        externalId: 'web-1-abc123',
+        name: 'web-1-abc123',
+        status: ServerStatus::Running,
+        type: 'custom',
+        region: 'local',
+    ));
+
+    $server = $service->find('web-1-abc123');
+
+    expect($server)->not->toBeNull()
+        ->and($server->name)->toBe('web-1-abc123');
+});
+
+test('find returns null when not found', function (): void {
+    $service = new InMemoryMultipassServerService();
+
+    expect($service->find('nonexistent'))->toBeNull();
+});
+
+test('destroy returns true and marks server deleted', function (): void {
+    $service = new InMemoryMultipassServerService();
+    $service->addServer(new ServerData(
+        externalId: 'web-1-abc123',
+        name: 'web-1-abc123',
+        status: ServerStatus::Running,
+        type: 'custom',
+        region: 'local',
+    ));
+
+    expect($service->destroy('web-1-abc123'))->toBeTrue()
+        ->and($service->getAll())->toHaveCount(0);
+});
+
+test('destroy returns false when not found', function (): void {
+    $service = new InMemoryMultipassServerService();
+
+    expect($service->destroy('nonexistent'))->toBeFalse();
+});
+
+test('destroy fails when configured to fail', function (): void {
+    $service = new InMemoryMultipassServerService();
+    $service->shouldFailDelete(true);
+
+    expect($service->destroy('web-1-abc123'))->toBeFalse();
+});

--- a/tests/Unit/Services/InMemory/InMemoryMultipassServiceTest.php
+++ b/tests/Unit/Services/InMemory/InMemoryMultipassServiceTest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Services\InMemory\InMemoryMultipassService;
+
+test('validates token returns true by default', function (): void {
+    $service = new InMemoryMultipassService();
+
+    expect($service->validateToken())->toBeTrue();
+});
+
+test('validates token returns configured result', function (): void {
+    $service = new InMemoryMultipassService();
+    $service->setValidationResult(false);
+
+    expect($service->validateToken())->toBeFalse();
+});

--- a/tests/Unit/Services/MultipassServerServiceTest.php
+++ b/tests/Unit/Services/MultipassServerServiceTest.php
@@ -1,0 +1,177 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Data\CreateServerData;
+use App\Enums\ServerStatus;
+use App\Services\MultipassServerService;
+use Illuminate\Support\Str;
+use Symfony\Component\Process\Process;
+
+function fakeMultipassProcess(array $responses): Closure
+{
+    $callIndex = 0;
+
+    return function (array $command) use ($responses, &$callIndex): Process {
+        $response = $responses[$callIndex] ?? ['success' => true, 'output' => ''];
+        $callIndex++;
+
+        if ($response['success']) {
+            $process = Process::fromShellCommandline('echo '.escapeshellarg($response['output'] ?? ''));
+        } else {
+            $process = Process::fromShellCommandline('echo '.escapeshellarg($response['error'] ?? 'error').' >&2 && exit 1');
+        }
+        $process->run();
+
+        return $process;
+    };
+}
+
+test('get all returns collection of server data', function (): void {
+    $json = json_encode([
+        'list' => [
+            [
+                'name' => 'web-1-abc123',
+                'state' => 'Running',
+                'ipv4' => ['192.168.64.2'],
+            ],
+        ],
+    ]);
+
+    $service = new MultipassServerService(fakeMultipassProcess([
+        ['success' => true, 'output' => $json],
+    ]));
+
+    $servers = $service->getAll();
+
+    expect($servers)->toHaveCount(1)
+        ->and($servers[0]->name)->toBe('web-1-abc123')
+        ->and($servers[0]->status)->toBe(ServerStatus::Running)
+        ->and($servers[0]->region)->toBe('local')
+        ->and($servers[0]->ipv4)->toBe('192.168.64.2');
+});
+
+test('get all throws on failure', function (): void {
+    $service = new MultipassServerService(fakeMultipassProcess([
+        ['success' => false, 'error' => 'multipass not running'],
+    ]));
+
+    $service->getAll();
+})->throws(RuntimeException::class, 'Failed to list Multipass VMs');
+
+test('create launches vm and returns server data', function (): void {
+    Str::createRandomStringsUsing(fn (): string => 'x1y2z3');
+
+    $infoJson = json_encode([
+        'info' => [
+            'web-1-x1y2z3' => [
+                'state' => 'Running',
+                'ipv4' => ['192.168.64.5'],
+            ],
+        ],
+    ]);
+
+    $service = new MultipassServerService(fakeMultipassProcess([
+        ['success' => true, 'output' => ''],           // launch
+        ['success' => true, 'output' => $infoJson],     // info
+    ]));
+
+    $server = $service->create(new CreateServerData(
+        name: 'web-1',
+        type: 'custom',
+        image: 'noble',
+        region: 'local',
+        infrastructure_id: 'infra-1',
+        cpus: 2,
+        memory: '2G',
+        disk: '20G',
+    ));
+
+    expect($server->name)->toBe('web-1-x1y2z3')
+        ->and($server->externalId)->toBe('web-1-x1y2z3')
+        ->and($server->status)->toBe(ServerStatus::Running)
+        ->and($server->ipv4)->toBe('192.168.64.5');
+});
+
+test('create throws on launch failure', function (): void {
+    $service = new MultipassServerService(fakeMultipassProcess([
+        ['success' => false, 'error' => 'launch failed'],
+    ]));
+
+    $service->create(new CreateServerData(
+        name: 'web-1',
+        type: 'custom',
+        image: 'noble',
+        region: 'local',
+        infrastructure_id: 'infra-1',
+    ));
+})->throws(RuntimeException::class, 'Failed to create Multipass VM');
+
+test('find returns server data when found', function (): void {
+    $infoJson = json_encode([
+        'info' => [
+            'web-1-abc123' => [
+                'state' => 'Stopped',
+                'ipv4' => ['192.168.64.2'],
+            ],
+        ],
+    ]);
+
+    $service = new MultipassServerService(fakeMultipassProcess([
+        ['success' => true, 'output' => $infoJson],
+    ]));
+
+    $server = $service->find('web-1-abc123');
+
+    expect($server)->not->toBeNull()
+        ->and($server->name)->toBe('web-1-abc123')
+        ->and($server->status)->toBe(ServerStatus::Off);
+});
+
+test('find returns null when not found', function (): void {
+    $service = new MultipassServerService(fakeMultipassProcess([
+        ['success' => false],
+    ]));
+
+    expect($service->find('nonexistent'))->toBeNull();
+});
+
+test('find returns null when name not in info response', function (): void {
+    $infoJson = json_encode([
+        'info' => [
+            'other-vm' => ['state' => 'Running', 'ipv4' => []],
+        ],
+    ]);
+
+    $service = new MultipassServerService(fakeMultipassProcess([
+        ['success' => true, 'output' => $infoJson],
+    ]));
+
+    expect($service->find('web-1-abc123'))->toBeNull();
+});
+
+test('destroy deletes and purges successfully', function (): void {
+    $service = new MultipassServerService(fakeMultipassProcess([
+        ['success' => true, 'output' => ''],  // delete
+        ['success' => true, 'output' => ''],  // purge
+    ]));
+
+    expect($service->destroy('web-1-abc123'))->toBeTrue();
+});
+
+test('destroy returns false when delete fails', function (): void {
+    $service = new MultipassServerService(fakeMultipassProcess([
+        ['success' => false, 'error' => 'not found'],
+    ]));
+
+    expect($service->destroy('nonexistent'))->toBeFalse();
+});
+
+test('destroy returns false when purge fails', function (): void {
+    $service = new MultipassServerService(fakeMultipassProcess([
+        ['success' => true, 'output' => ''],   // delete ok
+        ['success' => false, 'error' => 'purge failed'],  // purge fails
+    ]));
+
+    expect($service->destroy('web-1-abc123'))->toBeFalse();
+});

--- a/tests/Unit/Services/MultipassServiceTest.php
+++ b/tests/Unit/Services/MultipassServiceTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Services\MultipassService;
+use Symfony\Component\Process\Process;
+
+function fakeProcess(bool $successful = true, string $output = '', string $errorOutput = ''): Closure
+{
+    return function (array $command) use ($successful, $output): Process {
+        $process = new Process(['echo', 'fake']);
+        // We need a real process that returns controlled output
+        // Use a simple command that succeeds or fails
+        if ($successful) {
+            $process = Process::fromShellCommandline('echo '.escapeshellarg($output));
+        } else {
+            $process = Process::fromShellCommandline('exit 1');
+        }
+        $process->run();
+
+        return $process;
+    };
+}
+
+test('validate token returns true when multipass binary exists', function (): void {
+    $service = new MultipassService(fakeProcess(successful: true, output: 'multipass 1.14.0'));
+
+    expect($service->validateToken())->toBeTrue();
+});
+
+test('validate token returns false when multipass binary not found', function (): void {
+    $service = new MultipassService(fakeProcess(successful: false));
+
+    expect($service->validateToken())->toBeFalse();
+});


### PR DESCRIPTION
## Summary

- Implements `MultipassService` — validates `multipass` binary availability via `multipass version` (Symfony Process)
- Implements `MultipassServerService` — wraps Multipass CLI for VM CRUD: `list --format json`, `launch`, `info`, `delete` + `purge`
- Both services use injectable `Closure $processFactory` for testability — tests provide fake processes returning controlled output, no Multipass binary required
- VM naming: user base name + 6-char random suffix (e.g., `web-1-x1y2z3`), VM name used as external ID
- Adds `InMemoryMultipassService`, `InMemoryMultipassServerService`, `InMemoryMultipassFactory` mirroring Hetzner pattern
- Adds Pest.php helpers: `useInMemoryMultipassService()`, `useInMemoryMultipassServerService()`, `bindInMemoryMultipassFactory()`
- Wires Multipass into `CloudProviderFactory` (replaces placeholder throws)
- No phpunit.xml exclusions — real services fully tested via fake Process closures

Closes #32

## Test plan

- [x] 530 tests passing (1209 assertions)
- [x] 100% code coverage (no exclusions for Multipass)
- [x] Pint clean
- [x] Real service tests via fake Process closures (getAll, create, find, destroy + error paths)
- [x] InMemory double tests for all CRUD operations
- [x] Factory tests for Multipass wiring and fallback paths
- [x] MultipassService validation tests (binary exists / not found)

🤖 Generated with [Claude Code](https://claude.com/claude-code)