### PR TITLE
feat: Provider-type-aware prompts for Multipass in CreateServerCommand

### DIFF
--- a/app/Console/Commands/CreateServerCommand.php
+++ b/app/Console/Commands/CreateServerCommand.php
@@ -55,10 +55,32 @@ final class CreateServerCommand extends AuthenticatedCommand
             options: $choices,
         );
 
+        $selectedProvider = null;
+        foreach ($providers as $p) {
+            if ($p->id === $providerId) {
+                $selectedProvider = $p;
+                break;
+            }
+        }
+
+        $providerType = CloudProviderType::from($selectedProvider->type);
         $name = text(label: 'Server name', required: true);
-        $type = text(label: 'Server type', placeholder: 'e.g. cx11 (Hetzner) or s-1vcpu-1gb (DigitalOcean)', required: true);
-        $image = text(label: 'Image', default: 'ubuntu-22.04', required: true);
-        $region = text(label: 'Region', placeholder: 'e.g. fsn1 (Hetzner) or nyc1 (DigitalOcean)', required: true);
+
+        if ($providerType === CloudProviderType::Multipass) {
+            $image = text(label: 'Ubuntu release', default: 'noble', required: true);
+            $cpus = (int) text(label: 'CPUs', default: '1', required: true);
+            $memory = text(label: 'Memory', default: '1G', required: true);
+            $disk = text(label: 'Disk', default: '5G', required: true);
+            $type = 'custom';
+            $region = 'local';
+        } else {
+            $type = text(label: 'Server type', placeholder: 'e.g. cx11 (Hetzner) or s-1vcpu-1gb (DigitalOcean)', required: true);
+            $image = text(label: 'Image', default: 'ubuntu-22.04', required: true);
+            $region = text(label: 'Region', placeholder: 'e.g. fsn1 (Hetzner) or nyc1 (DigitalOcean)', required: true);
+            $cpus = null;
+            $memory = null;
+            $disk = null;
+        }
 
         $this->components->info('Creating server...');
 
@@ -70,6 +92,9 @@ final class CreateServerCommand extends AuthenticatedCommand
                     image: $image,
                     region: $region,
                     infrastructure_id: $this->infrastructure->id,
+                    cpus: $cpus,
+                    memory: $memory,
+                    disk: $disk,
                 ),
                 $providerId,
             );

--- a/app/Http/Controllers/Api/V1/ServerController.php
+++ b/app/Http/Controllers/Api/V1/ServerController.php
@@ -50,6 +50,9 @@ final class ServerController
                     image: $request->validated('image'),
                     region: $request->validated('region'),
                     infrastructure_id: $request->infrastructure->id,
+                    cpus: $request->validated('cpus') ? (int) $request->validated('cpus') : null,
+                    memory: $request->validated('memory'),
+                    disk: $request->validated('disk'),
                 ),
             );
         } catch (RuntimeException $e) {

--- a/app/Http/Requests/Api/V1/CreateServerRequest.php
+++ b/app/Http/Requests/Api/V1/CreateServerRequest.php
@@ -24,6 +24,9 @@ final class CreateServerRequest extends FormRequest
             'image' => ['required', 'string'],
             'region' => ['required', 'string'],
             'cloud_provider_id' => ['required', 'string', 'exists:cloud_providers,id'],
+            'cpus' => ['nullable', 'integer', 'min:1'],
+            'memory' => ['nullable', 'string'],
+            'disk' => ['nullable', 'string'],
         ];
     }
 }

--- a/tests/Feature/Commands/CreateServerCommandTest.php
+++ b/tests/Feature/Commands/CreateServerCommandTest.php
@@ -61,6 +61,40 @@ test('create server command creates server successfully',
             ->assertSuccessful();
     });
 
+test('create server command with multipass shows multipass-specific prompts',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var User $user */
+        $user = User::factory()->create(['email' => 'john@example.com', 'password' => 'password123']);
+        /** @var Organization $organization */
+        $organization = Organization::factory()->create();
+        $organization->users()->attach($user, ['role' => 'owner']);
+        /** @var Infrastructure $infrastructure */
+        $infrastructure = Infrastructure::factory()->create(['organization_id' => $organization->id]);
+
+        $userData = app(LoginUser::class)->handle('john@example.com', 'password123');
+        $session = app(SessionManager::class);
+        $session->setUser($userData);
+        $session->setOrganization(new SessionOrganizationData(id: $organization->id, name: $organization->name, slug: $organization->slug));
+        $session->setInfrastructure(new SessionInfrastructureData(id: $infrastructure->id, name: $infrastructure->name));
+
+        $this->cloudProviderClient->setListResponse([
+            new CloudProviderData(id: 'cp-mp', name: 'Local Multipass', type: 'multipass', isVerified: true),
+        ]);
+
+        $this->artisan('server:create')
+            ->expectsQuestion('Select a cloud provider', 'cp-mp')
+            ->expectsQuestion('Server name', 'web-1')
+            ->expectsQuestion('Ubuntu release', 'noble')
+            ->expectsQuestion('CPUs', '2')
+            ->expectsQuestion('Memory', '2G')
+            ->expectsQuestion('Disk', '20G')
+            ->expectsOutputToContain('Server [web-1] created successfully')
+            ->assertSuccessful();
+    });
+
 test('create server command displays error on list providers failure',
     /**
      * @throws Throwable


### PR DESCRIPTION
## Summary

- `CreateServerCommand` now checks the selected provider's type and shows different prompts:
  - **Multipass**: name, Ubuntu release, CPUs, memory, disk (type auto-set to `"custom"`, region to `"local"`)
  - **Hetzner/DigitalOcean**: name, type, image, region (unchanged)
- `CreateServerRequest` accepts nullable `cpus`, `memory`, `disk` fields
- `ServerController::store()` passes new fields through to `CreateServerData`

Closes #33

## Test plan

- [x] 505 tests passing (1173 assertions)
- [x] 100% code coverage
- [x] Pint clean
- [x] New test: Multipass-specific prompts (Ubuntu release, CPUs, memory, disk — no type/region)
- [x] Existing Hetzner test unchanged (still shows type/image/region prompts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)