### PR TITLE
feat: KubernetesCluster model enrichment with provisioning fields

### DIFF
--- a/app/Enums/ClusterTopology.php
+++ b/app/Enums/ClusterTopology.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+enum ClusterTopology: string
+{
+    case SingleCp = 'single_cp';
+    case Ha = 'ha';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::SingleCp => 'Single Control Plane',
+            self::Ha => 'High Availability',
+        };
+    }
+}

--- a/app/Enums/ProvisioningPhase.php
+++ b/app/Enums/ProvisioningPhase.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+enum ProvisioningPhase: string
+{
+    case Infrastructure = 'infrastructure';
+    case Configuration = 'configuration';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::Infrastructure => 'Infrastructure',
+            self::Configuration => 'Configuration',
+        };
+    }
+}

--- a/app/Models/KubernetesCluster.php
+++ b/app/Models/KubernetesCluster.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use App\Enums\ClusterTopology;
 use App\Enums\InfrastructureStatus;
+use App\Enums\ProvisioningPhase;
 use Carbon\CarbonImmutable;
 use Database\Factories\KubernetesClusterFactory;
 use Illuminate\Database\Eloquent\Collection;
@@ -23,6 +25,13 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
  * @property-read string|null $version
  * @property-read string|null $external_cluster_id
  * @property-read InfrastructureStatus $status
+ * @property-read string|null $kubeconfig
+ * @property-read string|null $api_endpoint
+ * @property-read string|null $pod_cidr
+ * @property-read string|null $service_cidr
+ * @property-read string|null $provisioning_step
+ * @property-read ProvisioningPhase|null $provisioning_phase
+ * @property-read ClusterTopology|null $topology
  * @property-read Infrastructure $infrastructure
  * @property-read Collection<int, Server> $nodes
  */
@@ -47,6 +56,13 @@ final class KubernetesCluster extends Model
             'version' => 'string',
             'external_cluster_id' => 'string',
             'status' => InfrastructureStatus::class,
+            'kubeconfig' => 'encrypted',
+            'api_endpoint' => 'string',
+            'pod_cidr' => 'string',
+            'service_cidr' => 'string',
+            'provisioning_step' => 'string',
+            'provisioning_phase' => ProvisioningPhase::class,
+            'topology' => ClusterTopology::class,
         ];
     }
 

--- a/database/factories/KubernetesClusterFactory.php
+++ b/database/factories/KubernetesClusterFactory.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Database\Factories;
 
+use App\Enums\ClusterTopology;
 use App\Enums\InfrastructureStatus;
+use App\Enums\ProvisioningPhase;
 use App\Models\Infrastructure;
 use App\Models\KubernetesCluster;
 use Illuminate\Database\Eloquent\Factories\Factory;
@@ -27,6 +29,32 @@ final class KubernetesClusterFactory extends Factory
             'version' => $this->faker->randomElement(['1.28', '1.29', '1.30']),
             'external_cluster_id' => $this->faker->uuid(),
             'status' => InfrastructureStatus::Healthy,
+            'topology' => $this->faker->randomElement(ClusterTopology::cases()),
+            'pod_cidr' => '10.244.0.0/16',
+            'service_cidr' => '10.96.0.0/12',
         ];
+    }
+
+    public function singleCp(): static
+    {
+        return $this->state(fn (): array => [
+            'topology' => ClusterTopology::SingleCp,
+        ]);
+    }
+
+    public function ha(): static
+    {
+        return $this->state(fn (): array => [
+            'topology' => ClusterTopology::Ha,
+        ]);
+    }
+
+    public function provisioning(): static
+    {
+        return $this->state(fn (): array => [
+            'status' => InfrastructureStatus::Provisioning,
+            'provisioning_phase' => ProvisioningPhase::Infrastructure,
+            'provisioning_step' => 'generate_ssh_keypairs',
+        ]);
     }
 }

--- a/database/migrations/2026_03_29_191033_add_provisioning_fields_to_kubernetes_clusters_table.php
+++ b/database/migrations/2026_03_29_191033_add_provisioning_fields_to_kubernetes_clusters_table.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('kubernetes_clusters', function (Blueprint $table) {
+            $table->text('kubeconfig')->nullable()->after('status');
+            $table->string('api_endpoint')->nullable()->after('kubeconfig');
+            $table->string('pod_cidr')->nullable()->after('api_endpoint');
+            $table->string('service_cidr')->nullable()->after('pod_cidr');
+            $table->string('provisioning_step')->nullable()->after('service_cidr');
+            $table->string('provisioning_phase')->nullable()->after('provisioning_step');
+            $table->string('topology')->nullable()->after('provisioning_phase');
+        });
+    }
+};

--- a/tests/Unit/Enums/ClusterTopologyTest.php
+++ b/tests/Unit/Enums/ClusterTopologyTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\ClusterTopology;
+
+test('label returns correct labels', function (): void {
+    expect(ClusterTopology::SingleCp->label())->toBe('Single Control Plane')
+        ->and(ClusterTopology::Ha->label())->toBe('High Availability');
+});
+
+test('cases returns all cases', function (): void {
+    expect(ClusterTopology::cases())->toBe([
+        ClusterTopology::SingleCp,
+        ClusterTopology::Ha,
+    ]);
+});

--- a/tests/Unit/Enums/ProvisioningPhaseTest.php
+++ b/tests/Unit/Enums/ProvisioningPhaseTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\ProvisioningPhase;
+
+test('label returns correct labels', function (): void {
+    expect(ProvisioningPhase::Infrastructure->label())->toBe('Infrastructure')
+        ->and(ProvisioningPhase::Configuration->label())->toBe('Configuration');
+});
+
+test('cases returns all cases', function (): void {
+    expect(ProvisioningPhase::cases())->toBe([
+        ProvisioningPhase::Infrastructure,
+        ProvisioningPhase::Configuration,
+    ]);
+});

--- a/tests/Unit/Models/KubernetesClusterTest.php
+++ b/tests/Unit/Models/KubernetesClusterTest.php
@@ -2,11 +2,110 @@
 
 declare(strict_types=1);
 
+use App\Enums\ClusterTopology;
 use App\Enums\InfrastructureStatus;
+use App\Enums\ProvisioningPhase;
 use App\Models\Infrastructure;
 use App\Models\KubernetesCluster;
 use App\Models\Server;
 use Carbon\CarbonImmutable;
+use Illuminate\Support\Facades\DB;
+
+test('stores and retrieves encrypted kubeconfig',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var KubernetesCluster $cluster */
+        $cluster = KubernetesCluster::factory()->createQuietly([
+            'kubeconfig' => 'apiVersion: v1\nclusters:\n- cluster: {}',
+        ]);
+
+        $raw = DB::table('kubernetes_clusters')
+            ->where('id', $cluster->id)
+            ->value('kubeconfig');
+
+        expect($raw)->not->toBe('apiVersion: v1\nclusters:\n- cluster: {}')
+            ->and($cluster->kubeconfig)->toBe('apiVersion: v1\nclusters:\n- cluster: {}');
+    });
+
+test('casts topology as enum',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var KubernetesCluster $cluster */
+        $cluster = KubernetesCluster::factory()->createQuietly([
+            'topology' => ClusterTopology::Ha,
+        ]);
+
+        expect($cluster->topology)->toBe(ClusterTopology::Ha);
+    });
+
+test('casts provisioning phase as enum',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var KubernetesCluster $cluster */
+        $cluster = KubernetesCluster::factory()->createQuietly([
+            'provisioning_phase' => ProvisioningPhase::Configuration,
+        ]);
+
+        expect($cluster->provisioning_phase)->toBe(ProvisioningPhase::Configuration);
+    });
+
+test('stores network configuration fields',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var KubernetesCluster $cluster */
+        $cluster = KubernetesCluster::factory()->createQuietly([
+            'api_endpoint' => 'https://10.0.1.10:6443',
+            'pod_cidr' => '10.244.0.0/16',
+            'service_cidr' => '10.96.0.0/12',
+        ]);
+
+        expect($cluster->api_endpoint)->toBe('https://10.0.1.10:6443')
+            ->and($cluster->pod_cidr)->toBe('10.244.0.0/16')
+            ->and($cluster->service_cidr)->toBe('10.96.0.0/12');
+    });
+
+test('single cp factory state',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var KubernetesCluster $cluster */
+        $cluster = KubernetesCluster::factory()->singleCp()->createQuietly();
+
+        expect($cluster->topology)->toBe(ClusterTopology::SingleCp);
+    });
+
+test('ha factory state',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var KubernetesCluster $cluster */
+        $cluster = KubernetesCluster::factory()->ha()->createQuietly();
+
+        expect($cluster->topology)->toBe(ClusterTopology::Ha);
+    });
+
+test('provisioning factory state',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var KubernetesCluster $cluster */
+        $cluster = KubernetesCluster::factory()->provisioning()->createQuietly();
+
+        expect($cluster->status)->toBe(InfrastructureStatus::Provisioning)
+            ->and($cluster->provisioning_phase)->toBe(ProvisioningPhase::Infrastructure)
+            ->and($cluster->provisioning_step)->toBe('generate_ssh_keypairs');
+    });
 
 test('creates kubernetes cluster',
     /**
@@ -107,5 +206,12 @@ test('to array has all fields in correct order',
                 'version',
                 'external_cluster_id',
                 'status',
+                'kubeconfig',
+                'api_endpoint',
+                'pod_cidr',
+                'service_cidr',
+                'provisioning_step',
+                'provisioning_phase',
+                'topology',
             ]);
     });


### PR DESCRIPTION
## Summary

- Add `kubeconfig` (encrypted), `api_endpoint`, `pod_cidr`, `service_cidr`, `provisioning_step`, `provisioning_phase`, `topology` to KubernetesCluster model
- Add `ClusterTopology` enum (`SingleCp` / `Ha`)
- Add `ProvisioningPhase` enum (`Infrastructure` / `Configuration`)
- Factory gains `singleCp()`, `ha()`, `provisioning()` states
- `cni` field intentionally omitted — Cilium is always the CNI per ADR-0004
- `provisioning_step` stays as string — enum cast added in #44

Closes #43

## Test plan

- [ ] `ClusterTopologyTest` — 2 tests (labels, cases)
- [ ] `ProvisioningPhaseTest` — 2 tests (labels, cases)
- [ ] `KubernetesClusterTest` — 7 new tests (encrypted kubeconfig, topology cast, phase cast, network fields, factory states)
- [ ] Full suite passes (620 tests)
- [ ] Pint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for cluster topology management with Single Control Plane and High Availability options
  * Added provisioning phase tracking to monitor cluster deployment progress
  * Added network configuration storage for cluster settings (API endpoint, pod CIDR, service CIDR)
  * Added secure kubeconfig storage

* **Tests**
  * Added comprehensive unit tests for new cluster topology and provisioning capabilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->