### PR TITLE
feat: ProvisioningStep enum + state machine on Infrastructure

### DIFF
--- a/app/Enums/ProvisioningStep.php
+++ b/app/Enums/ProvisioningStep.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+enum ProvisioningStep: string
+{
+    // Infrastructure phase (steps 1-10)
+    case GenerateSshKeypairs = 'generate_ssh_keypairs';
+    case RegisterSshKeys = 'register_ssh_keys';
+    case CreateNetwork = 'create_network';
+    case CreateFirewallRules = 'create_firewall_rules';
+    case CreateBastion = 'create_bastion';
+    case WaitForBastion = 'wait_for_bastion';
+    case ScpToBastion = 'scp_to_bastion';
+    case CreateControlPlaneNodes = 'create_control_plane_nodes';
+    case CreateWorkerNodes = 'create_worker_nodes';
+    case WaitForNodes = 'wait_for_nodes';
+
+    // Configuration phase (steps 11-17)
+    case GenerateInventory = 'generate_inventory';
+    case ScpInventory = 'scp_inventory';
+    case RunAnsible = 'run_ansible';
+    case RetrieveKubeconfig = 'retrieve_kubeconfig';
+    case StoreKubeconfig = 'store_kubeconfig';
+    case HealthCheck = 'health_check';
+    case MarkHealthy = 'mark_healthy';
+
+    public static function first(): self
+    {
+        return self::GenerateSshKeypairs;
+    }
+
+    public function phase(): ProvisioningPhase
+    {
+        return match ($this) {
+            self::GenerateSshKeypairs,
+            self::RegisterSshKeys,
+            self::CreateNetwork,
+            self::CreateFirewallRules,
+            self::CreateBastion,
+            self::WaitForBastion,
+            self::ScpToBastion,
+            self::CreateControlPlaneNodes,
+            self::CreateWorkerNodes,
+            self::WaitForNodes => ProvisioningPhase::Infrastructure,
+
+            self::GenerateInventory,
+            self::ScpInventory,
+            self::RunAnsible,
+            self::RetrieveKubeconfig,
+            self::StoreKubeconfig,
+            self::HealthCheck,
+            self::MarkHealthy => ProvisioningPhase::Configuration,
+        };
+    }
+
+    public function nextStep(): ?self
+    {
+        $cases = self::cases();
+        $index = array_search($this, $cases, true);
+
+        return $cases[$index + 1] ?? null;
+    }
+
+    public function isTerminal(): bool
+    {
+        return $this === self::MarkHealthy;
+    }
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::GenerateSshKeypairs => 'Generate SSH Keypairs',
+            self::RegisterSshKeys => 'Register SSH Keys',
+            self::CreateNetwork => 'Create Network',
+            self::CreateFirewallRules => 'Create Firewall Rules',
+            self::CreateBastion => 'Create Bastion',
+            self::WaitForBastion => 'Wait For Bastion',
+            self::ScpToBastion => 'SCP To Bastion',
+            self::CreateControlPlaneNodes => 'Create Control Plane Nodes',
+            self::CreateWorkerNodes => 'Create Worker Nodes',
+            self::WaitForNodes => 'Wait For Nodes',
+            self::GenerateInventory => 'Generate Inventory',
+            self::ScpInventory => 'SCP Inventory',
+            self::RunAnsible => 'Run Ansible',
+            self::RetrieveKubeconfig => 'Retrieve Kubeconfig',
+            self::StoreKubeconfig => 'Store Kubeconfig',
+            self::HealthCheck => 'Health Check',
+            self::MarkHealthy => 'Mark Healthy',
+        };
+    }
+}

--- a/app/Jobs/ProcessProvisioningStep.php
+++ b/app/Jobs/ProcessProvisioningStep.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Jobs;
+
+use App\Enums\InfrastructureStatus;
+use App\Models\Infrastructure;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Throwable;
+
+final class ProcessProvisioningStep implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(public Infrastructure $infrastructure) {}
+
+    public function handle(): void
+    {
+        $currentStep = $this->infrastructure->provisioning_step;
+
+        if ($currentStep === null || $currentStep->isTerminal()) {
+            $this->infrastructure->update([
+                'status' => InfrastructureStatus::Healthy,
+            ]);
+
+            return;
+        }
+
+        // TODO: Execute the actual step logic (delegated to step handlers in #47/#48/#52)
+
+        $nextStep = $currentStep->nextStep();
+
+        $this->infrastructure->update([
+            'provisioning_step' => $nextStep,
+            'provisioning_phase' => $nextStep?->phase(),
+        ]);
+
+        if ($nextStep !== null) {
+            self::dispatch($this->infrastructure);
+        }
+    }
+
+    public function failed(Throwable $exception): void
+    {
+        $this->infrastructure->update([
+            'status' => InfrastructureStatus::Failed,
+        ]);
+    }
+}

--- a/app/Models/Infrastructure.php
+++ b/app/Models/Infrastructure.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace App\Models;
 
 use App\Enums\InfrastructureStatus;
+use App\Enums\ProvisioningPhase;
+use App\Enums\ProvisioningStep;
 use Carbon\CarbonImmutable;
 use Database\Factories\InfrastructureFactory;
 use Illuminate\Database\Eloquent\Collection;
@@ -24,6 +26,8 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
  * @property-read string $name
  * @property-read string|null $description
  * @property-read InfrastructureStatus $status
+ * @property-read ProvisioningStep|null $provisioning_step
+ * @property-read ProvisioningPhase|null $provisioning_phase
  * @property-read Organization $organization
  * @property-read CloudProvider $cloudProvider
  * @property-read Region|null $region
@@ -57,6 +61,8 @@ final class Infrastructure extends Model
             'name' => 'string',
             'description' => 'string',
             'status' => InfrastructureStatus::class,
+            'provisioning_step' => ProvisioningStep::class,
+            'provisioning_phase' => ProvisioningPhase::class,
         ];
     }
 

--- a/app/Models/KubernetesCluster.php
+++ b/app/Models/KubernetesCluster.php
@@ -6,7 +6,6 @@ namespace App\Models;
 
 use App\Enums\ClusterTopology;
 use App\Enums\InfrastructureStatus;
-use App\Enums\ProvisioningPhase;
 use Carbon\CarbonImmutable;
 use Database\Factories\KubernetesClusterFactory;
 use Illuminate\Database\Eloquent\Collection;
@@ -29,8 +28,6 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
  * @property-read string|null $api_endpoint
  * @property-read string|null $pod_cidr
  * @property-read string|null $service_cidr
- * @property-read string|null $provisioning_step
- * @property-read ProvisioningPhase|null $provisioning_phase
  * @property-read ClusterTopology|null $topology
  * @property-read Infrastructure $infrastructure
  * @property-read Collection<int, Server> $nodes
@@ -60,8 +57,6 @@ final class KubernetesCluster extends Model
             'api_endpoint' => 'string',
             'pod_cidr' => 'string',
             'service_cidr' => 'string',
-            'provisioning_step' => 'string',
-            'provisioning_phase' => ProvisioningPhase::class,
             'topology' => ClusterTopology::class,
         ];
     }

--- a/database/factories/InfrastructureFactory.php
+++ b/database/factories/InfrastructureFactory.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Database\Factories;
 
 use App\Enums\InfrastructureStatus;
+use App\Enums\ProvisioningPhase;
+use App\Enums\ProvisioningStep;
 use App\Models\CloudProvider;
 use App\Models\Infrastructure;
 use App\Models\Organization;
@@ -34,7 +36,11 @@ final class InfrastructureFactory extends Factory
 
     public function provisioning(): self
     {
-        return $this->state(['status' => InfrastructureStatus::Provisioning]);
+        return $this->state([
+            'status' => InfrastructureStatus::Provisioning,
+            'provisioning_step' => ProvisioningStep::GenerateSshKeypairs,
+            'provisioning_phase' => ProvisioningPhase::Infrastructure,
+        ]);
     }
 
     public function degraded(): self

--- a/database/factories/KubernetesClusterFactory.php
+++ b/database/factories/KubernetesClusterFactory.php
@@ -6,7 +6,6 @@ namespace Database\Factories;
 
 use App\Enums\ClusterTopology;
 use App\Enums\InfrastructureStatus;
-use App\Enums\ProvisioningPhase;
 use App\Models\Infrastructure;
 use App\Models\KubernetesCluster;
 use Illuminate\Database\Eloquent\Factories\Factory;
@@ -46,15 +45,6 @@ final class KubernetesClusterFactory extends Factory
     {
         return $this->state(fn (): array => [
             'topology' => ClusterTopology::Ha,
-        ]);
-    }
-
-    public function provisioning(): static
-    {
-        return $this->state(fn (): array => [
-            'status' => InfrastructureStatus::Provisioning,
-            'provisioning_phase' => ProvisioningPhase::Infrastructure,
-            'provisioning_step' => 'generate_ssh_keypairs',
         ]);
     }
 }

--- a/database/migrations/2026_03_29_193831_add_provisioning_and_cluster_fields.php
+++ b/database/migrations/2026_03_29_193831_add_provisioning_and_cluster_fields.php
@@ -10,14 +10,17 @@ return new class extends Migration
 {
     public function up(): void
     {
+        Schema::table('infrastructures', function (Blueprint $table) {
+            $table->string('provisioning_step')->nullable()->after('status');
+            $table->string('provisioning_phase')->nullable()->after('provisioning_step');
+        });
+
         Schema::table('kubernetes_clusters', function (Blueprint $table) {
             $table->text('kubeconfig')->nullable()->after('status');
             $table->string('api_endpoint')->nullable()->after('kubeconfig');
             $table->string('pod_cidr')->nullable()->after('api_endpoint');
             $table->string('service_cidr')->nullable()->after('pod_cidr');
-            $table->string('provisioning_step')->nullable()->after('service_cidr');
-            $table->string('provisioning_phase')->nullable()->after('provisioning_step');
-            $table->string('topology')->nullable()->after('provisioning_phase');
+            $table->string('topology')->nullable()->after('service_cidr');
         });
     }
 };

--- a/tests/Unit/Enums/ProvisioningStepTest.php
+++ b/tests/Unit/Enums/ProvisioningStepTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\ProvisioningPhase;
+use App\Enums\ProvisioningStep;
+
+test('cases returns all 17 steps', function (): void {
+    expect(ProvisioningStep::cases())->toHaveCount(17);
+});
+
+test('infrastructure phase steps', function (): void {
+    $infrastructureSteps = [
+        ProvisioningStep::GenerateSshKeypairs,
+        ProvisioningStep::RegisterSshKeys,
+        ProvisioningStep::CreateNetwork,
+        ProvisioningStep::CreateFirewallRules,
+        ProvisioningStep::CreateBastion,
+        ProvisioningStep::WaitForBastion,
+        ProvisioningStep::ScpToBastion,
+        ProvisioningStep::CreateControlPlaneNodes,
+        ProvisioningStep::CreateWorkerNodes,
+        ProvisioningStep::WaitForNodes,
+    ];
+
+    foreach ($infrastructureSteps as $step) {
+        expect($step->phase())->toBe(ProvisioningPhase::Infrastructure, "Step {$step->value} should be infrastructure phase");
+    }
+});
+
+test('configuration phase steps', function (): void {
+    $configurationSteps = [
+        ProvisioningStep::GenerateInventory,
+        ProvisioningStep::ScpInventory,
+        ProvisioningStep::RunAnsible,
+        ProvisioningStep::RetrieveKubeconfig,
+        ProvisioningStep::StoreKubeconfig,
+        ProvisioningStep::HealthCheck,
+        ProvisioningStep::MarkHealthy,
+    ];
+
+    foreach ($configurationSteps as $step) {
+        expect($step->phase())->toBe(ProvisioningPhase::Configuration, "Step {$step->value} should be configuration phase");
+    }
+});
+
+test('next step returns correct sequence', function (): void {
+    expect(ProvisioningStep::GenerateSshKeypairs->nextStep())->toBe(ProvisioningStep::RegisterSshKeys)
+        ->and(ProvisioningStep::RegisterSshKeys->nextStep())->toBe(ProvisioningStep::CreateNetwork)
+        ->and(ProvisioningStep::CreateNetwork->nextStep())->toBe(ProvisioningStep::CreateFirewallRules)
+        ->and(ProvisioningStep::CreateFirewallRules->nextStep())->toBe(ProvisioningStep::CreateBastion)
+        ->and(ProvisioningStep::CreateBastion->nextStep())->toBe(ProvisioningStep::WaitForBastion)
+        ->and(ProvisioningStep::WaitForBastion->nextStep())->toBe(ProvisioningStep::ScpToBastion)
+        ->and(ProvisioningStep::ScpToBastion->nextStep())->toBe(ProvisioningStep::CreateControlPlaneNodes)
+        ->and(ProvisioningStep::CreateControlPlaneNodes->nextStep())->toBe(ProvisioningStep::CreateWorkerNodes)
+        ->and(ProvisioningStep::CreateWorkerNodes->nextStep())->toBe(ProvisioningStep::WaitForNodes)
+        ->and(ProvisioningStep::WaitForNodes->nextStep())->toBe(ProvisioningStep::GenerateInventory)
+        ->and(ProvisioningStep::GenerateInventory->nextStep())->toBe(ProvisioningStep::ScpInventory)
+        ->and(ProvisioningStep::ScpInventory->nextStep())->toBe(ProvisioningStep::RunAnsible)
+        ->and(ProvisioningStep::RunAnsible->nextStep())->toBe(ProvisioningStep::RetrieveKubeconfig)
+        ->and(ProvisioningStep::RetrieveKubeconfig->nextStep())->toBe(ProvisioningStep::StoreKubeconfig)
+        ->and(ProvisioningStep::StoreKubeconfig->nextStep())->toBe(ProvisioningStep::HealthCheck)
+        ->and(ProvisioningStep::HealthCheck->nextStep())->toBe(ProvisioningStep::MarkHealthy);
+});
+
+test('terminal step returns null', function (): void {
+    expect(ProvisioningStep::MarkHealthy->nextStep())->toBeNull();
+});
+
+test('is terminal returns true only for last step', function (): void {
+    expect(ProvisioningStep::MarkHealthy->isTerminal())->toBeTrue()
+        ->and(ProvisioningStep::GenerateSshKeypairs->isTerminal())->toBeFalse()
+        ->and(ProvisioningStep::HealthCheck->isTerminal())->toBeFalse();
+});
+
+test('first returns the initial step', function (): void {
+    expect(ProvisioningStep::first())->toBe(ProvisioningStep::GenerateSshKeypairs);
+});
+
+test('label returns human readable labels', function (): void {
+    expect(ProvisioningStep::GenerateSshKeypairs->label())->toBe('Generate SSH Keypairs')
+        ->and(ProvisioningStep::RunAnsible->label())->toBe('Run Ansible')
+        ->and(ProvisioningStep::MarkHealthy->label())->toBe('Mark Healthy');
+});

--- a/tests/Unit/Jobs/ProcessProvisioningStepTest.php
+++ b/tests/Unit/Jobs/ProcessProvisioningStepTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\InfrastructureStatus;
+use App\Enums\ProvisioningPhase;
+use App\Enums\ProvisioningStep;
+use App\Jobs\ProcessProvisioningStep;
+use App\Models\Infrastructure;
+use Illuminate\Support\Facades\Bus;
+
+test('advances to next step and dispatches itself',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        Bus::fake([ProcessProvisioningStep::class]);
+
+        /** @var Infrastructure $infrastructure */
+        $infrastructure = Infrastructure::factory()->provisioning()->createQuietly();
+
+        expect($infrastructure->provisioning_step)->toBe(ProvisioningStep::GenerateSshKeypairs);
+
+        $job = new ProcessProvisioningStep($infrastructure);
+        $job->handle();
+
+        $infrastructure->refresh();
+
+        expect($infrastructure->provisioning_step)->toBe(ProvisioningStep::RegisterSshKeys)
+            ->and($infrastructure->provisioning_phase)->toBe(ProvisioningPhase::Infrastructure);
+
+        Bus::assertDispatched(ProcessProvisioningStep::class);
+    });
+
+test('marks infrastructure healthy on terminal step',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        Bus::fake([ProcessProvisioningStep::class]);
+
+        /** @var Infrastructure $infrastructure */
+        $infrastructure = Infrastructure::factory()->createQuietly([
+            'status' => InfrastructureStatus::Provisioning,
+            'provisioning_step' => ProvisioningStep::MarkHealthy,
+            'provisioning_phase' => ProvisioningPhase::Configuration,
+        ]);
+
+        $job = new ProcessProvisioningStep($infrastructure);
+        $job->handle();
+
+        $infrastructure->refresh();
+
+        expect($infrastructure->status)->toBe(InfrastructureStatus::Healthy)
+            ->and($infrastructure->provisioning_step)->toBe(ProvisioningStep::MarkHealthy);
+
+        Bus::assertNotDispatched(ProcessProvisioningStep::class);
+    });
+
+test('marks infrastructure failed on exception',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var Infrastructure $infrastructure */
+        $infrastructure = Infrastructure::factory()->provisioning()->createQuietly();
+
+        $job = new ProcessProvisioningStep($infrastructure);
+        $job->failed(new RuntimeException('Simulated failure'));
+
+        $infrastructure->refresh();
+
+        expect($infrastructure->status)->toBe(InfrastructureStatus::Failed);
+    });
+
+test('updates phase when crossing from infrastructure to configuration',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        Bus::fake([ProcessProvisioningStep::class]);
+
+        /** @var Infrastructure $infrastructure */
+        $infrastructure = Infrastructure::factory()->createQuietly([
+            'status' => InfrastructureStatus::Provisioning,
+            'provisioning_step' => ProvisioningStep::WaitForNodes,
+            'provisioning_phase' => ProvisioningPhase::Infrastructure,
+        ]);
+
+        $job = new ProcessProvisioningStep($infrastructure);
+        $job->handle();
+
+        $infrastructure->refresh();
+
+        expect($infrastructure->provisioning_step)->toBe(ProvisioningStep::GenerateInventory)
+            ->and($infrastructure->provisioning_phase)->toBe(ProvisioningPhase::Configuration);
+    });

--- a/tests/Unit/Models/InfrastructureTest.php
+++ b/tests/Unit/Models/InfrastructureTest.php
@@ -3,6 +3,8 @@
 declare(strict_types=1);
 
 use App\Enums\InfrastructureStatus;
+use App\Enums\ProvisioningPhase;
+use App\Enums\ProvisioningStep;
 use App\Models\Backup;
 use App\Models\CloudProvider;
 use App\Models\Firewall;
@@ -15,6 +17,45 @@ use App\Models\Region;
 use App\Models\SshKey;
 use App\Models\Storage;
 use Carbon\CarbonImmutable;
+
+test('casts provisioning step as enum',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var Infrastructure $infrastructure */
+        $infrastructure = Infrastructure::factory()->createQuietly([
+            'provisioning_step' => ProvisioningStep::CreateBastion,
+        ]);
+
+        expect($infrastructure->provisioning_step)->toBe(ProvisioningStep::CreateBastion);
+    });
+
+test('casts provisioning phase as enum',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var Infrastructure $infrastructure */
+        $infrastructure = Infrastructure::factory()->createQuietly([
+            'provisioning_phase' => ProvisioningPhase::Configuration,
+        ]);
+
+        expect($infrastructure->provisioning_phase)->toBe(ProvisioningPhase::Configuration);
+    });
+
+test('provisioning factory state sets step and phase',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var Infrastructure $infrastructure */
+        $infrastructure = Infrastructure::factory()->provisioning()->createQuietly();
+
+        expect($infrastructure->status)->toBe(InfrastructureStatus::Provisioning)
+            ->and($infrastructure->provisioning_step)->toBe(ProvisioningStep::GenerateSshKeypairs)
+            ->and($infrastructure->provisioning_phase)->toBe(ProvisioningPhase::Infrastructure);
+    });
 
 test('creates infrastructure',
     /**
@@ -258,5 +299,7 @@ test('to array has all fields in correct order',
                 'name',
                 'description',
                 'status',
+                'provisioning_step',
+                'provisioning_phase',
             ]);
     });

--- a/tests/Unit/Models/KubernetesClusterTest.php
+++ b/tests/Unit/Models/KubernetesClusterTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 use App\Enums\ClusterTopology;
 use App\Enums\InfrastructureStatus;
-use App\Enums\ProvisioningPhase;
 use App\Models\Infrastructure;
 use App\Models\KubernetesCluster;
 use App\Models\Server;
@@ -40,19 +39,6 @@ test('casts topology as enum',
         ]);
 
         expect($cluster->topology)->toBe(ClusterTopology::Ha);
-    });
-
-test('casts provisioning phase as enum',
-    /**
-     * @throws Throwable
-     */
-    function (): void {
-        /** @var KubernetesCluster $cluster */
-        $cluster = KubernetesCluster::factory()->createQuietly([
-            'provisioning_phase' => ProvisioningPhase::Configuration,
-        ]);
-
-        expect($cluster->provisioning_phase)->toBe(ProvisioningPhase::Configuration);
     });
 
 test('stores network configuration fields',
@@ -92,19 +78,6 @@ test('ha factory state',
         $cluster = KubernetesCluster::factory()->ha()->createQuietly();
 
         expect($cluster->topology)->toBe(ClusterTopology::Ha);
-    });
-
-test('provisioning factory state',
-    /**
-     * @throws Throwable
-     */
-    function (): void {
-        /** @var KubernetesCluster $cluster */
-        $cluster = KubernetesCluster::factory()->provisioning()->createQuietly();
-
-        expect($cluster->status)->toBe(InfrastructureStatus::Provisioning)
-            ->and($cluster->provisioning_phase)->toBe(ProvisioningPhase::Infrastructure)
-            ->and($cluster->provisioning_step)->toBe('generate_ssh_keypairs');
     });
 
 test('creates kubernetes cluster',
@@ -210,8 +183,6 @@ test('to array has all fields in correct order',
                 'api_endpoint',
                 'pod_cidr',
                 'service_cidr',
-                'provisioning_step',
-                'provisioning_phase',
                 'topology',
             ]);
     });


### PR DESCRIPTION
## Summary

- Add `ProvisioningStep` enum with 17 cases (phase(), nextStep(), isTerminal(), first(), label())
- Move `provisioning_step` and `provisioning_phase` from KubernetesCluster to Infrastructure — provisioning is an infrastructure concern
- Add `ProcessProvisioningStep` job skeleton: advances state, self-dispatches, marks healthy/failed
- KubernetesCluster keeps only cluster-specific fields: kubeconfig, api_endpoint, pod_cidr, service_cidr, topology
- Infrastructure factory gains provisioning step/phase in `provisioning()` state
- Replace migration to split fields between infrastructures and kubernetes_clusters tables

Closes #43, closes #44

## Test plan

- [ ] `ProvisioningStepTest` — 8 tests (cases count, phase classification, step sequence, terminal, first, labels)
- [ ] `ProcessProvisioningStepTest` — 4 tests (advance, terminal, failure, phase crossing)
- [ ] `InfrastructureTest` — 3 new tests (step cast, phase cast, provisioning factory state) + updated toArray
- [ ] `KubernetesClusterTest` — provisioning tests removed, cluster-specific tests kept
- [ ] Full suite passes (633 tests)
- [ ] Pint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced an ordered step-based provisioning workflow for infrastructure deployment organized into distinct phases.
  * Infrastructure now tracks current provisioning step and phase, enabling improved visibility into deployment progress.

* **Tests**
  * Added comprehensive unit test coverage for the provisioning workflow and step progression logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->