### PR TITLE
feat: SshKeyService contract + Multipass/Hetzner implementations

### DIFF
--- a/app/Contracts/SshKeyService.php
+++ b/app/Contracts/SshKeyService.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Contracts;
+
+use App\Data\SshKeyData;
+use Illuminate\Support\Collection;
+
+interface SshKeyService
+{
+    public function register(string $name, string $publicKey): SshKeyData;
+
+    public function list(): Collection;
+
+    public function delete(int|string $externalId): bool;
+}

--- a/app/Data/SshKeyData.php
+++ b/app/Data/SshKeyData.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Data;
+
+final readonly class SshKeyData
+{
+    public function __construct(
+        public int|string $externalId,
+        public string $name,
+        public string $fingerprint,
+        public string $publicKey,
+    ) {}
+}

--- a/app/Services/CloudProviderFactory.php
+++ b/app/Services/CloudProviderFactory.php
@@ -8,6 +8,7 @@ use App\Contracts\CloudProviderService;
 use App\Contracts\FirewallService;
 use App\Contracts\NetworkService;
 use App\Contracts\ServerService;
+use App\Contracts\SshKeyService;
 use App\Enums\CloudProviderType;
 use RuntimeException;
 
@@ -37,6 +38,15 @@ class CloudProviderFactory
             CloudProviderType::Hetzner => new HetznerFirewallService($token ?? ''),
             CloudProviderType::DigitalOcean => throw new RuntimeException('Firewall service for DigitalOcean is not yet implemented.'),
             CloudProviderType::Multipass => new MultipassFirewallService(),
+        };
+    }
+
+    public function makeSshKeyService(CloudProviderType $type, ?string $token = null): SshKeyService
+    {
+        return match ($type) {
+            CloudProviderType::Hetzner => new HetznerSshKeyService($token ?? ''),
+            CloudProviderType::DigitalOcean => throw new RuntimeException('SSH key service for DigitalOcean is not yet implemented.'),
+            CloudProviderType::Multipass => new MultipassSshKeyService(),
         };
     }
 

--- a/app/Services/HetznerSshKeyService.php
+++ b/app/Services/HetznerSshKeyService.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Contracts\SshKeyService;
+use App\Data\SshKeyData;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Http;
+use RuntimeException;
+
+final readonly class HetznerSshKeyService implements SshKeyService
+{
+    public function __construct(private string $token) {}
+
+    /**
+     * @throws ConnectionException
+     * @throws RuntimeException
+     */
+    public function register(string $name, string $publicKey): SshKeyData
+    {
+        $response = Http::withToken($this->token)
+            ->post('https://api.hetzner.cloud/v1/ssh_keys', [
+                'name' => $name,
+                'public_key' => $publicKey,
+            ]);
+
+        if (! $response->successful()) {
+            throw new RuntimeException($response->json('error.message', 'Failed to register SSH key on Hetzner.'));
+        }
+
+        return $this->mapSshKeyData($response->json('ssh_key'));
+    }
+
+    /**
+     * @throws ConnectionException
+     * @throws RuntimeException
+     */
+    public function list(): Collection
+    {
+        $response = Http::withToken($this->token)
+            ->get('https://api.hetzner.cloud/v1/ssh_keys');
+
+        if (! $response->successful()) {
+            throw new RuntimeException($response->json('error.message', 'Failed to list SSH keys on Hetzner.'));
+        }
+
+        return collect($response->json('ssh_keys', []))
+            ->map($this->mapSshKeyData(...));
+    }
+
+    /**
+     * @throws ConnectionException
+     */
+    public function delete(int|string $externalId): bool
+    {
+        $response = Http::withToken($this->token)
+            ->delete("https://api.hetzner.cloud/v1/ssh_keys/{$externalId}");
+
+        return $response->successful();
+    }
+
+    /**
+     * @param  array<string, mixed>  $sshKey
+     */
+    private function mapSshKeyData(array $sshKey): SshKeyData
+    {
+        return new SshKeyData(
+            externalId: $sshKey['id'],
+            name: $sshKey['name'],
+            fingerprint: $sshKey['fingerprint'],
+            publicKey: $sshKey['public_key'],
+        );
+    }
+}

--- a/app/Services/InMemory/InMemorySshKeyService.php
+++ b/app/Services/InMemory/InMemorySshKeyService.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\InMemory;
+
+use App\Contracts\SshKeyService;
+use App\Data\SshKeyData;
+use Illuminate\Support\Collection;
+use RuntimeException;
+
+final class InMemorySshKeyService implements SshKeyService
+{
+    /** @var Collection<int, SshKeyData> */
+    private Collection $keys;
+
+    private bool $failRegister = false;
+
+    private bool $failDelete = false;
+
+    private int $nextId = 1;
+
+    public function __construct()
+    {
+        $this->keys = collect();
+    }
+
+    public function addKey(SshKeyData $key): self
+    {
+        $this->keys->push($key);
+
+        $externalId = (string) $key->externalId;
+
+        if (ctype_digit($externalId) && (int) $externalId >= $this->nextId) {
+            $this->nextId = (int) $externalId + 1;
+        }
+
+        return $this;
+    }
+
+    public function shouldFailRegister(bool $fail = true): self
+    {
+        $this->failRegister = $fail;
+
+        return $this;
+    }
+
+    public function shouldFailDelete(bool $fail = true): self
+    {
+        $this->failDelete = $fail;
+
+        return $this;
+    }
+
+    public function register(string $name, string $publicKey): SshKeyData
+    {
+        if ($this->failRegister) {
+            throw new RuntimeException('Simulated API failure on register');
+        }
+
+        $key = new SshKeyData(
+            externalId: (string) $this->nextId++,
+            name: $name,
+            fingerprint: md5($publicKey),
+            publicKey: $publicKey,
+        );
+
+        $this->keys->push($key);
+
+        return $key;
+    }
+
+    public function list(): Collection
+    {
+        return $this->keys->values();
+    }
+
+    public function delete(int|string $externalId): bool
+    {
+        if ($this->failDelete) {
+            return false;
+        }
+
+        $before = $this->keys->count();
+        $this->keys = $this->keys->reject(
+            fn (SshKeyData $key): bool => (string) $key->externalId === (string) $externalId
+        )->values();
+
+        return $this->keys->count() < $before;
+    }
+}

--- a/app/Services/MultipassSshKeyService.php
+++ b/app/Services/MultipassSshKeyService.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Contracts\SshKeyService;
+use App\Data\SshKeyData;
+use Illuminate\Support\Collection;
+
+final readonly class MultipassSshKeyService implements SshKeyService
+{
+    public function register(string $name, string $publicKey): SshKeyData
+    {
+        return new SshKeyData(
+            externalId: 'multipass-'.$name,
+            name: $name,
+            fingerprint: md5($publicKey),
+            publicKey: $publicKey,
+        );
+    }
+
+    public function list(): Collection
+    {
+        return collect();
+    }
+
+    public function delete(int|string $externalId): bool
+    {
+        return true;
+    }
+}

--- a/tests/Unit/Services/CloudProviderServiceFactoryTest.php
+++ b/tests/Unit/Services/CloudProviderServiceFactoryTest.php
@@ -10,8 +10,30 @@ use App\Services\HetznerFirewallService;
 use App\Services\HetznerNetworkService;
 use App\Services\HetznerServerService;
 use App\Services\HetznerService;
+use App\Services\HetznerSshKeyService;
 use App\Services\MultipassFirewallService;
 use App\Services\MultipassNetworkService;
+use App\Services\MultipassSshKeyService;
+
+test('make ssh key service returns hetzner ssh key service', function (): void {
+    $factory = new CloudProviderFactory;
+    $service = $factory->makeSshKeyService(CloudProviderType::Hetzner, 'token');
+
+    expect($service)->toBeInstanceOf(HetznerSshKeyService::class);
+});
+
+test('make ssh key service returns multipass ssh key service', function (): void {
+    $factory = new CloudProviderFactory;
+    $service = $factory->makeSshKeyService(CloudProviderType::Multipass);
+
+    expect($service)->toBeInstanceOf(MultipassSshKeyService::class);
+});
+
+test('make ssh key service throws for digital ocean', function (): void {
+    $factory = new CloudProviderFactory;
+
+    $factory->makeSshKeyService(CloudProviderType::DigitalOcean, 'token');
+})->throws(RuntimeException::class, 'SSH key service for DigitalOcean is not yet implemented.');
 
 test('make network service returns hetzner network service', function (): void {
     $factory = new CloudProviderFactory;

--- a/tests/Unit/Services/HetznerSshKeyServiceTest.php
+++ b/tests/Unit/Services/HetznerSshKeyServiceTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Services\HetznerSshKeyService;
+use Illuminate\Support\Facades\Http;
+
+test('register throws on api error', function (): void {
+    Http::fake([
+        'api.hetzner.cloud/v1/ssh_keys' => Http::response([
+            'error' => ['message' => 'invalid public key', 'code' => 'invalid_input'],
+        ], 422),
+    ]);
+
+    $service = new HetznerSshKeyService('token');
+
+    $service->register('deploy-key', 'invalid-key');
+})->throws(RuntimeException::class, 'invalid public key');
+
+test('register returns ssh key data', function (): void {
+    Http::fake([
+        'api.hetzner.cloud/v1/ssh_keys' => Http::response([
+            'ssh_key' => [
+                'id' => 123,
+                'name' => 'deploy-key',
+                'fingerprint' => 'ab:cd:ef:12:34',
+                'public_key' => 'ssh-ed25519 AAAA...',
+            ],
+        ]),
+    ]);
+
+    $service = new HetznerSshKeyService('token');
+    $key = $service->register('deploy-key', 'ssh-ed25519 AAAA...');
+
+    expect($key->externalId)->toBe(123)
+        ->and($key->name)->toBe('deploy-key')
+        ->and($key->fingerprint)->toBe('ab:cd:ef:12:34')
+        ->and($key->publicKey)->toBe('ssh-ed25519 AAAA...');
+});
+
+test('list returns collection of ssh key data', function (): void {
+    Http::fake([
+        'api.hetzner.cloud/v1/ssh_keys' => Http::response([
+            'ssh_keys' => [
+                [
+                    'id' => 123,
+                    'name' => 'deploy-key',
+                    'fingerprint' => 'ab:cd:ef:12:34',
+                    'public_key' => 'ssh-ed25519 AAAA...',
+                ],
+                [
+                    'id' => 456,
+                    'name' => 'bastion-key',
+                    'fingerprint' => 'fe:dc:ba:56:78',
+                    'public_key' => 'ssh-ed25519 BBBB...',
+                ],
+            ],
+        ]),
+    ]);
+
+    $service = new HetznerSshKeyService('token');
+    $keys = $service->list();
+
+    expect($keys)->toHaveCount(2)
+        ->and($keys[0]->externalId)->toBe(123)
+        ->and($keys[1]->externalId)->toBe(456);
+});
+
+test('list throws on api error', function (): void {
+    Http::fake([
+        'api.hetzner.cloud/v1/ssh_keys' => Http::response([
+            'error' => ['message' => 'unauthorized', 'code' => 'unauthorized'],
+        ], 401),
+    ]);
+
+    $service = new HetznerSshKeyService('token');
+
+    $service->list();
+})->throws(RuntimeException::class, 'unauthorized');
+
+test('delete returns true on success', function (): void {
+    Http::fake([
+        'api.hetzner.cloud/v1/ssh_keys/123' => Http::response([], 200),
+    ]);
+
+    $service = new HetznerSshKeyService('token');
+
+    expect($service->delete(123))->toBeTrue();
+});
+
+test('delete returns false on failure', function (): void {
+    Http::fake([
+        'api.hetzner.cloud/v1/ssh_keys/999' => Http::response([], 404),
+    ]);
+
+    $service = new HetznerSshKeyService('token');
+
+    expect($service->delete(999))->toBeFalse();
+});

--- a/tests/Unit/Services/InMemory/InMemorySshKeyServiceTest.php
+++ b/tests/Unit/Services/InMemory/InMemorySshKeyServiceTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Data\SshKeyData;
+use App\Services\InMemory\InMemorySshKeyService;
+
+test('register stores and returns ssh key data', function (): void {
+    $service = new InMemorySshKeyService();
+    $key = $service->register('deploy-key', 'ssh-ed25519 AAAA...');
+
+    expect($key->name)->toBe('deploy-key')
+        ->and($key->publicKey)->toBe('ssh-ed25519 AAAA...')
+        ->and($service->list())->toHaveCount(1);
+});
+
+test('register throws when configured to fail', function (): void {
+    $service = new InMemorySshKeyService();
+    $service->shouldFailRegister();
+
+    $service->register('deploy-key', 'ssh-ed25519 AAAA...');
+})->throws(RuntimeException::class);
+
+test('list returns all keys', function (): void {
+    $service = new InMemorySshKeyService();
+    $service->addKey(new SshKeyData(externalId: '1', name: 'key-1', fingerprint: 'fp-1', publicKey: 'pk-1'));
+    $service->addKey(new SshKeyData(externalId: '2', name: 'key-2', fingerprint: 'fp-2', publicKey: 'pk-2'));
+
+    expect($service->list())->toHaveCount(2);
+});
+
+test('delete removes key and returns true', function (): void {
+    $service = new InMemorySshKeyService();
+    $service->addKey(new SshKeyData(externalId: '123', name: 'key-1', fingerprint: 'fp-1', publicKey: 'pk-1'));
+
+    expect($service->delete('123'))->toBeTrue()
+        ->and($service->list())->toBeEmpty();
+});
+
+test('delete returns false when not found', function (): void {
+    $service = new InMemorySshKeyService();
+
+    expect($service->delete('nonexistent'))->toBeFalse();
+});
+
+test('delete returns false when configured to fail', function (): void {
+    $service = new InMemorySshKeyService();
+    $service->addKey(new SshKeyData(externalId: '123', name: 'key-1', fingerprint: 'fp-1', publicKey: 'pk-1'));
+    $service->shouldFailDelete();
+
+    expect($service->delete('123'))->toBeFalse();
+});

--- a/tests/Unit/Services/MultipassSshKeyServiceTest.php
+++ b/tests/Unit/Services/MultipassSshKeyServiceTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Services\MultipassSshKeyService;
+
+test('register returns ssh key data with provided values', function (): void {
+    $service = new MultipassSshKeyService();
+    $key = $service->register('deploy-key', 'ssh-ed25519 AAAA...');
+
+    expect($key->name)->toBe('deploy-key')
+        ->and($key->publicKey)->toBe('ssh-ed25519 AAAA...')
+        ->and($key->externalId)->toBe('multipass-deploy-key');
+});
+
+test('list returns empty collection', function (): void {
+    $service = new MultipassSshKeyService();
+
+    expect($service->list())->toBeEmpty();
+});
+
+test('delete returns true', function (): void {
+    $service = new MultipassSshKeyService();
+
+    expect($service->delete('any-id'))->toBeTrue();
+});


### PR DESCRIPTION
## Summary

- Add `SshKeyService` contract with `register()`, `list()`, `delete()` methods
- Add `SshKeyData` DTO
- `HetznerSshKeyService`: calls Hetzner Cloud API for SSH key management
- `MultipassSshKeyService`: no-op (cloud-init handles key injection)
- `InMemorySshKeyService`: stateful test double with deterministic IDs
- Wire into `CloudProviderFactory::makeSshKeyService()`, DO throws RuntimeException

Closes #40

## Test plan

- [ ] `HetznerSshKeyServiceTest` — 6 tests (register, list, delete + error handling)
- [ ] `MultipassSshKeyServiceTest` — 3 tests (no-op behavior)
- [ ] `InMemorySshKeyServiceTest` — 6 tests (state management + failure modes)
- [ ] `CloudProviderServiceFactoryTest` — 3 new tests (factory wiring + DO throws)
- [ ] Full suite passes (651 tests)
- [ ] Pint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added SSH key management functionality for cloud provider integrations
  * Users can now register, list, and delete SSH keys with support for Hetzner and Multipass cloud providers

* **Tests**
  * Added comprehensive unit test coverage for SSH key service implementations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->