### PR TITLE
feat: Node provisioning pipeline steps 8-10

### DIFF
--- a/app/Actions/CreateControlPlaneNodes.php
+++ b/app/Actions/CreateControlPlaneNodes.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions;
+
+use App\Contracts\StepHandler;
+use App\Data\CreateServerData;
+use App\Enums\CloudProviderType;
+use App\Enums\ClusterTopology;
+use App\Enums\ServerRole;
+use App\Models\Infrastructure;
+use App\Queries\ServerQuery;
+use App\Queries\SshKeyQuery;
+
+final readonly class CreateControlPlaneNodes implements StepHandler
+{
+    public function __construct(
+        private CreateServer $createServer,
+        private ServerQuery $serverQuery,
+        private SshKeyQuery $sshKeyQuery,
+    ) {}
+
+    public function handle(Infrastructure $infrastructure): void
+    {
+        if (($this->serverQuery)()->byInfrastructure($infrastructure)->byRole(ServerRole::ControlPlane)->exists()) {
+            return;
+        }
+
+        $provider = $infrastructure->cloudProvider;
+        $spec = $provider->type->controlPlaneSpec();
+        $topology = self::topologyFor($provider->type);
+
+        $sshKeyIds = ($this->sshKeyQuery)()
+            ->byInfrastructure($infrastructure)
+            ->get()
+            ->whereNotNull('external_ssh_key_id')
+            ->pluck('external_ssh_key_id')
+            ->map(fn (string $id): int|string => is_numeric($id) ? (int) $id : $id)
+            ->all();
+
+        $nodeCount = $topology === ClusterTopology::Ha ? 3 : 1;
+
+        for ($i = 1; $i <= $nodeCount; $i++) {
+            $this->createServer->handle($provider, new CreateServerData(
+                name: "{$infrastructure->name}-cp-{$i}",
+                type: $spec->type,
+                image: $spec->image,
+                region: $spec->region,
+                infrastructure_id: $infrastructure->id,
+                role: ServerRole::ControlPlane,
+                cpus: $spec->cpus,
+                memory: $spec->memory,
+                disk: $spec->disk,
+                sshKeyIds: $sshKeyIds,
+            ));
+        }
+    }
+
+    private static function topologyFor(CloudProviderType $type): ClusterTopology
+    {
+        return match ($type) {
+            CloudProviderType::Multipass => ClusterTopology::SingleCp,
+            default => ClusterTopology::Ha,
+        };
+    }
+}

--- a/app/Actions/CreateWorkerNodes.php
+++ b/app/Actions/CreateWorkerNodes.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions;
+
+use App\Contracts\StepHandler;
+use App\Data\CreateServerData;
+use App\Enums\ServerRole;
+use App\Models\Infrastructure;
+use App\Queries\ServerQuery;
+use App\Queries\SshKeyQuery;
+
+final readonly class CreateWorkerNodes implements StepHandler
+{
+    private const int DEFAULT_WORKER_COUNT = 2;
+
+    public function __construct(
+        private CreateServer $createServer,
+        private ServerQuery $serverQuery,
+        private SshKeyQuery $sshKeyQuery,
+    ) {}
+
+    public function handle(Infrastructure $infrastructure): void
+    {
+        if (($this->serverQuery)()->byInfrastructure($infrastructure)->byRole(ServerRole::Node)->exists()) {
+            return;
+        }
+
+        $provider = $infrastructure->cloudProvider;
+        $spec = $provider->type->workerSpec();
+
+        $sshKeyIds = ($this->sshKeyQuery)()
+            ->byInfrastructure($infrastructure)
+            ->get()
+            ->whereNotNull('external_ssh_key_id')
+            ->pluck('external_ssh_key_id')
+            ->map(fn (string $id): int|string => is_numeric($id) ? (int) $id : $id)
+            ->all();
+
+        for ($i = 1; $i <= self::DEFAULT_WORKER_COUNT; $i++) {
+            $this->createServer->handle($provider, new CreateServerData(
+                name: "{$infrastructure->name}-worker-{$i}",
+                type: $spec->type,
+                image: $spec->image,
+                region: $spec->region,
+                infrastructure_id: $infrastructure->id,
+                role: ServerRole::Node,
+                cpus: $spec->cpus,
+                memory: $spec->memory,
+                disk: $spec->disk,
+                sshKeyIds: $sshKeyIds,
+            ));
+        }
+    }
+}

--- a/app/Actions/WaitForNodes.php
+++ b/app/Actions/WaitForNodes.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions;
+
+use App\Contracts\StepHandler;
+use App\Enums\ServerRole;
+use App\Enums\ServerStatus;
+use App\Exceptions\RetryStepException;
+use App\Models\Infrastructure;
+use App\Models\Server;
+use App\Queries\ServerQuery;
+use App\Services\CloudProviderFactory;
+use RuntimeException;
+
+final readonly class WaitForNodes implements StepHandler
+{
+    public function __construct(
+        private CloudProviderFactory $factory,
+        private ServerQuery $serverQuery,
+    ) {}
+
+    public function handle(Infrastructure $infrastructure): void
+    {
+        $nodes = ($this->serverQuery)()
+            ->byInfrastructure($infrastructure)
+            ->builder()
+            ->whereIn('role', [ServerRole::ControlPlane, ServerRole::Node])
+            ->get();
+
+        if ($nodes->isEmpty()) {
+            throw new RuntimeException('No cluster nodes found for infrastructure: '.$infrastructure->id);
+        }
+
+        $provider = $infrastructure->cloudProvider;
+        $serverService = $this->factory->makeServerService($provider->type, $provider->api_token);
+
+        $allRunning = true;
+
+        $nodes->each(function (Server $node) use ($serverService, &$allRunning): void {
+            $current = $serverService->find($node->name);
+
+            if ($current !== null) {
+                $node->update(['status' => $current->status, 'ipv4' => $current->ipv4]);
+            }
+
+            $node->refresh();
+
+            if ($node->status !== ServerStatus::Running) {
+                $allRunning = false;
+            }
+        });
+
+        if (! $allRunning) {
+            throw new RetryStepException('Not all cluster nodes are running yet.');
+        }
+    }
+}

--- a/app/Jobs/ProcessProvisioningStep.php
+++ b/app/Jobs/ProcessProvisioningStep.php
@@ -5,12 +5,15 @@ declare(strict_types=1);
 namespace App\Jobs;
 
 use App\Actions\CreateBastion;
+use App\Actions\CreateControlPlaneNodes;
 use App\Actions\CreateFirewallForInfrastructure;
 use App\Actions\CreateNetworkForInfrastructure;
+use App\Actions\CreateWorkerNodes;
 use App\Actions\GenerateSshKeypairs;
 use App\Actions\RegisterSshKeys;
 use App\Actions\ScpToBastion;
 use App\Actions\WaitForBastion;
+use App\Actions\WaitForNodes;
 use App\Contracts\StepHandler;
 use App\Enums\InfrastructureStatus;
 use App\Enums\ProvisioningStep;
@@ -111,8 +114,11 @@ final class ProcessProvisioningStep implements ShouldQueue
             ProvisioningStep::CreateBastion => app(CreateBastion::class),
             ProvisioningStep::WaitForBastion => app(WaitForBastion::class),
             ProvisioningStep::ScpToBastion => app(ScpToBastion::class),
+            ProvisioningStep::CreateControlPlaneNodes => app(CreateControlPlaneNodes::class),
+            ProvisioningStep::CreateWorkerNodes => app(CreateWorkerNodes::class),
+            ProvisioningStep::WaitForNodes => app(WaitForNodes::class),
 
-            // Steps 8-17 will be implemented in #48 and #52
+            // Steps 11-17 will be implemented in #52
             default => throw new LogicException("No handler registered for provisioning step: {$step->value}"),
         };
     }

--- a/tests/Unit/Actions/CreateControlPlaneNodesTest.php
+++ b/tests/Unit/Actions/CreateControlPlaneNodesTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\CreateControlPlaneNodes;
+use App\Actions\CreateServer;
+use App\Enums\CloudProviderType;
+use App\Enums\ServerRole;
+use App\Models\CloudProvider;
+use App\Models\Infrastructure;
+use App\Models\Server;
+use App\Models\SshKey;
+use App\Queries\ServerQuery;
+use App\Queries\SshKeyQuery;
+use App\Services\CloudProviderFactory;
+use App\Services\InMemory\InMemoryHetznerServerService;
+
+test('creates single control plane node for multipass',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var CloudProvider $provider */
+        $provider = CloudProvider::factory()->createQuietly([
+            'type' => CloudProviderType::Multipass,
+        ]);
+
+        /** @var Infrastructure $infrastructure */
+        $infrastructure = Infrastructure::factory()->provisioning()->createQuietly([
+            'cloud_provider_id' => $provider->id,
+            'organization_id' => $provider->organization_id,
+        ]);
+
+        SshKey::factory()->node()->createQuietly([
+            'infrastructure_id' => $infrastructure->id,
+            'external_ssh_key_id' => '456',
+        ]);
+
+        $serverService = new InMemoryHetznerServerService();
+
+        $factory = Mockery::mock(CloudProviderFactory::class);
+        $factory->shouldReceive('makeServerService')
+            ->with($provider->type, $provider->api_token)
+            ->once()
+            ->andReturn($serverService);
+
+        $createServer = new CreateServer($factory);
+
+        $action = new CreateControlPlaneNodes($createServer, new ServerQuery(), new SshKeyQuery());
+        $action->handle($infrastructure);
+
+        $cpNodes = Server::where('infrastructure_id', $infrastructure->id)
+            ->where('role', ServerRole::ControlPlane)
+            ->get();
+
+        expect($cpNodes)->toHaveCount(1)
+            ->and($cpNodes[0]->name)->toContain('cp-1');
+    });
+
+test('creates three control plane nodes for hetzner',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var CloudProvider $provider */
+        $provider = CloudProvider::factory()->createQuietly([
+            'type' => CloudProviderType::Hetzner,
+        ]);
+
+        /** @var Infrastructure $infrastructure */
+        $infrastructure = Infrastructure::factory()->provisioning()->createQuietly([
+            'cloud_provider_id' => $provider->id,
+            'organization_id' => $provider->organization_id,
+        ]);
+
+        SshKey::factory()->node()->createQuietly([
+            'infrastructure_id' => $infrastructure->id,
+            'external_ssh_key_id' => '456',
+        ]);
+
+        $serverService = new InMemoryHetznerServerService();
+
+        $factory = Mockery::mock(CloudProviderFactory::class);
+        $factory->shouldReceive('makeServerService')
+            ->with($provider->type, $provider->api_token)
+            ->times(3)
+            ->andReturn($serverService);
+
+        $createServer = new CreateServer($factory);
+
+        $action = new CreateControlPlaneNodes($createServer, new ServerQuery(), new SshKeyQuery());
+        $action->handle($infrastructure);
+
+        $cpNodes = Server::where('infrastructure_id', $infrastructure->id)
+            ->where('role', ServerRole::ControlPlane)
+            ->get();
+
+        expect($cpNodes)->toHaveCount(3);
+    });
+
+test('skips if control plane nodes already exist',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var Infrastructure $infrastructure */
+        $infrastructure = Infrastructure::factory()->provisioning()->createQuietly();
+
+        Server::factory()->createQuietly([
+            'infrastructure_id' => $infrastructure->id,
+            'role' => ServerRole::ControlPlane,
+        ]);
+
+        $factory = Mockery::mock(CloudProviderFactory::class);
+        $factory->shouldNotReceive('makeServerService');
+
+        $createServer = new CreateServer($factory);
+
+        $action = new CreateControlPlaneNodes($createServer, new ServerQuery(), new SshKeyQuery());
+        $action->handle($infrastructure);
+
+        $cpNodes = Server::where('infrastructure_id', $infrastructure->id)
+            ->where('role', ServerRole::ControlPlane)
+            ->get();
+
+        expect($cpNodes)->toHaveCount(1);
+    });

--- a/tests/Unit/Actions/CreateWorkerNodesTest.php
+++ b/tests/Unit/Actions/CreateWorkerNodesTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\CreateServer;
+use App\Actions\CreateWorkerNodes;
+use App\Enums\ServerRole;
+use App\Models\CloudProvider;
+use App\Models\Infrastructure;
+use App\Models\Server;
+use App\Models\SshKey;
+use App\Queries\ServerQuery;
+use App\Queries\SshKeyQuery;
+use App\Services\CloudProviderFactory;
+use App\Services\InMemory\InMemoryHetznerServerService;
+
+test('creates two worker nodes by default',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var CloudProvider $provider */
+        $provider = CloudProvider::factory()->createQuietly();
+
+        /** @var Infrastructure $infrastructure */
+        $infrastructure = Infrastructure::factory()->provisioning()->createQuietly([
+            'cloud_provider_id' => $provider->id,
+            'organization_id' => $provider->organization_id,
+        ]);
+
+        SshKey::factory()->node()->createQuietly([
+            'infrastructure_id' => $infrastructure->id,
+            'external_ssh_key_id' => '456',
+        ]);
+
+        $serverService = new InMemoryHetznerServerService();
+
+        $factory = Mockery::mock(CloudProviderFactory::class);
+        $factory->shouldReceive('makeServerService')
+            ->with($provider->type, $provider->api_token)
+            ->times(2)
+            ->andReturn($serverService);
+
+        $createServer = new CreateServer($factory);
+
+        $action = new CreateWorkerNodes($createServer, new ServerQuery(), new SshKeyQuery());
+        $action->handle($infrastructure);
+
+        $workers = Server::where('infrastructure_id', $infrastructure->id)
+            ->where('role', ServerRole::Node)
+            ->get();
+
+        expect($workers)->toHaveCount(2)
+            ->and($workers[0]->name)->toContain('worker-1')
+            ->and($workers[1]->name)->toContain('worker-2');
+    });
+
+test('skips if worker nodes already exist',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var Infrastructure $infrastructure */
+        $infrastructure = Infrastructure::factory()->provisioning()->createQuietly();
+
+        Server::factory()->createQuietly([
+            'infrastructure_id' => $infrastructure->id,
+            'role' => ServerRole::Node,
+        ]);
+
+        $factory = Mockery::mock(CloudProviderFactory::class);
+        $factory->shouldNotReceive('makeServerService');
+
+        $createServer = new CreateServer($factory);
+
+        $action = new CreateWorkerNodes($createServer, new ServerQuery(), new SshKeyQuery());
+        $action->handle($infrastructure);
+
+        $workers = Server::where('infrastructure_id', $infrastructure->id)
+            ->where('role', ServerRole::Node)
+            ->get();
+
+        expect($workers)->toHaveCount(1);
+    });

--- a/tests/Unit/Actions/WaitForNodesTest.php
+++ b/tests/Unit/Actions/WaitForNodesTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\WaitForNodes;
+use App\Data\ServerData;
+use App\Enums\ServerRole;
+use App\Enums\ServerStatus;
+use App\Exceptions\RetryStepException;
+use App\Models\CloudProvider;
+use App\Models\Infrastructure;
+use App\Models\Server;
+use App\Queries\ServerQuery;
+use App\Services\CloudProviderFactory;
+use App\Services\InMemory\InMemoryHetznerServerService;
+
+test('succeeds when all nodes are running',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var CloudProvider $provider */
+        $provider = CloudProvider::factory()->createQuietly();
+
+        /** @var Infrastructure $infrastructure */
+        $infrastructure = Infrastructure::factory()->provisioning()->createQuietly([
+            'cloud_provider_id' => $provider->id,
+        ]);
+
+        /** @var Server $cp */
+        $cp = Server::factory()->createQuietly([
+            'infrastructure_id' => $infrastructure->id,
+            'cloud_provider_id' => $provider->id,
+            'role' => ServerRole::ControlPlane,
+            'status' => ServerStatus::Starting,
+            'name' => 'test-cp-1',
+        ]);
+
+        /** @var Server $worker */
+        $worker = Server::factory()->createQuietly([
+            'infrastructure_id' => $infrastructure->id,
+            'cloud_provider_id' => $provider->id,
+            'role' => ServerRole::Node,
+            'status' => ServerStatus::Starting,
+            'name' => 'test-worker-1',
+        ]);
+
+        $serverService = new InMemoryHetznerServerService();
+        $serverService->addServer(new ServerData(externalId: $cp->external_id, name: 'test-cp-1', status: ServerStatus::Running, type: 'cx32', region: 'hel1', ipv4: '10.0.1.1'));
+        $serverService->addServer(new ServerData(externalId: $worker->external_id, name: 'test-worker-1', status: ServerStatus::Running, type: 'cx32', region: 'hel1', ipv4: '10.0.2.1'));
+
+        $factory = Mockery::mock(CloudProviderFactory::class);
+        $factory->shouldReceive('makeServerService')->andReturn($serverService);
+
+        $action = new WaitForNodes($factory, new ServerQuery());
+        $action->handle($infrastructure);
+
+        $cp->refresh();
+        $worker->refresh();
+
+        expect($cp->status)->toBe(ServerStatus::Running)
+            ->and($worker->status)->toBe(ServerStatus::Running);
+    });
+
+test('throws retry exception when any node is not running',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var CloudProvider $provider */
+        $provider = CloudProvider::factory()->createQuietly();
+
+        /** @var Infrastructure $infrastructure */
+        $infrastructure = Infrastructure::factory()->provisioning()->createQuietly([
+            'cloud_provider_id' => $provider->id,
+        ]);
+
+        Server::factory()->createQuietly([
+            'infrastructure_id' => $infrastructure->id,
+            'cloud_provider_id' => $provider->id,
+            'role' => ServerRole::ControlPlane,
+            'status' => ServerStatus::Starting,
+            'name' => 'test-cp-1',
+        ]);
+
+        $serverService = new InMemoryHetznerServerService();
+        $serverService->addServer(new ServerData(externalId: 'ext-1', name: 'test-cp-1', status: ServerStatus::Starting, type: 'cx32', region: 'hel1'));
+
+        $factory = Mockery::mock(CloudProviderFactory::class);
+        $factory->shouldReceive('makeServerService')->andReturn($serverService);
+
+        $action = new WaitForNodes($factory, new ServerQuery());
+        $action->handle($infrastructure);
+    })->throws(RetryStepException::class);
+
+test('throws when no cluster nodes exist',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var Infrastructure $infrastructure */
+        $infrastructure = Infrastructure::factory()->provisioning()->createQuietly();
+
+        $factory = Mockery::mock(CloudProviderFactory::class);
+
+        $action = new WaitForNodes($factory, new ServerQuery());
+        $action->handle($infrastructure);
+    })->throws(RuntimeException::class, 'No cluster nodes found');

--- a/tests/Unit/Jobs/ProcessProvisioningStepTest.php
+++ b/tests/Unit/Jobs/ProcessProvisioningStepTest.php
@@ -78,26 +78,6 @@ test('marks infrastructure failed on exception',
         expect($infrastructure->status)->toBe(InfrastructureStatus::Failed);
     });
 
-test('updates phase when crossing from infrastructure to configuration',
-    /**
-     * @throws Throwable
-     */
-    function (): void {
-        Bus::fake([ProcessProvisioningStep::class]);
-
-        /** @var Infrastructure $infrastructure */
-        $infrastructure = Infrastructure::factory()->createQuietly([
-            'status' => InfrastructureStatus::Provisioning,
-            'provisioning_step' => ProvisioningStep::WaitForNodes,
-            'provisioning_phase' => ProvisioningPhase::Infrastructure,
-        ]);
-
-        $job = new ProcessProvisioningStep($infrastructure);
-
-        // WaitForNodes has no handler yet (steps 8-17), so it throws LogicException
-        expect(fn () => $job->handle())->toThrow(LogicException::class);
-    });
-
 test('throws logic exception for unimplemented steps',
     /**
      * @throws Throwable
@@ -106,8 +86,8 @@ test('throws logic exception for unimplemented steps',
         /** @var Infrastructure $infrastructure */
         $infrastructure = Infrastructure::factory()->createQuietly([
             'status' => InfrastructureStatus::Provisioning,
-            'provisioning_step' => ProvisioningStep::CreateControlPlaneNodes,
-            'provisioning_phase' => ProvisioningPhase::Infrastructure,
+            'provisioning_step' => ProvisioningStep::GenerateInventory,
+            'provisioning_phase' => ProvisioningPhase::Configuration,
         ]);
 
         $job = new ProcessProvisioningStep($infrastructure);


### PR DESCRIPTION
## Summary

- **CreateControlPlaneNodes** — creates 1 (Multipass/SingleCp) or 3 (Hetzner/Ha) CP nodes
- **CreateWorkerNodes** — creates 2 worker nodes (default count)
- **WaitForNodes** — polls cloud API for all CP + worker nodes, RetryStepException if not running
- All implement `StepHandler`, delegate to `CreateServer`, use Query classes (CQRS), idempotent
- Topology derived from `CloudProviderType` (Multipass=SingleCp, Hetzner=Ha)
- Wired into `ProcessProvisioningStep` job (steps 8-10)

Closes #48

## Test plan

- [ ] `CreateControlPlaneNodesTest` — single CP (Multipass), HA (Hetzner), idempotency
- [ ] `CreateWorkerNodesTest` — 2 workers, idempotency
- [ ] `WaitForNodesTest` — all running, retry, no nodes
- [ ] `ProcessProvisioningStepTest` — updated for new step coverage
- [ ] Full suite passes (696 tests)
- [ ] Pint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)