### PR TITLE
feat: private network only for CP and worker nodes

### DIFF
--- a/app/Actions/CreateBastion.php
+++ b/app/Actions/CreateBastion.php
@@ -45,6 +45,7 @@ final readonly class CreateBastion implements StepHandler
 
         $cloudInitYaml = $this->cloudInit->bastion(bastionPublicKey: $bastionKey->public_key);
         $spec = $provider->type->bastionSpec();
+        $networkId = $infrastructure->networks()->first()?->external_network_id;
 
         $this->createServer->handle($provider, new CreateServerData(
             name: "{$infrastructure->name}-bastion",
@@ -58,6 +59,7 @@ final readonly class CreateBastion implements StepHandler
             disk: $spec->disk,
             sshKeyIds: $sshKeyIds,
             cloudInit: $cloudInitYaml,
+            networkId: $networkId,
         ));
     }
 }

--- a/app/Actions/CreateControlPlaneNodes.php
+++ b/app/Actions/CreateControlPlaneNodes.php
@@ -39,6 +39,8 @@ final readonly class CreateControlPlaneNodes implements StepHandler
             ->map(fn (string $id): int|string => is_numeric($id) ? (int) $id : $id)
             ->all();
 
+        $networkId = $infrastructure->networks()->first()?->external_network_id;
+
         $nodeCount = $topology === ClusterTopology::Ha ? 3 : 1;
 
         for ($i = 1; $i <= $nodeCount; $i++) {
@@ -53,6 +55,8 @@ final readonly class CreateControlPlaneNodes implements StepHandler
                 memory: $spec->memory,
                 disk: $spec->disk,
                 sshKeyIds: $sshKeyIds,
+                publicIp: false,
+                networkId: $networkId,
             ));
         }
     }

--- a/app/Actions/CreateWorkerNodes.php
+++ b/app/Actions/CreateWorkerNodes.php
@@ -38,6 +38,8 @@ final readonly class CreateWorkerNodes implements StepHandler
             ->map(fn (string $id): int|string => is_numeric($id) ? (int) $id : $id)
             ->all();
 
+        $networkId = $infrastructure->networks()->first()?->external_network_id;
+
         for ($i = 1; $i <= self::DEFAULT_WORKER_COUNT; $i++) {
             $this->createServer->handle($provider, new CreateServerData(
                 name: "{$infrastructure->name}-worker-{$i}",
@@ -50,6 +52,8 @@ final readonly class CreateWorkerNodes implements StepHandler
                 memory: $spec->memory,
                 disk: $spec->disk,
                 sshKeyIds: $sshKeyIds,
+                publicIp: false,
+                networkId: $networkId,
             ));
         }
     }

--- a/app/Data/CreateServerData.php
+++ b/app/Data/CreateServerData.php
@@ -23,5 +23,7 @@ final readonly class CreateServerData
         public ?string $disk = null,
         public array $sshKeyIds = [],
         public ?string $cloudInit = null,
+        public bool $publicIp = true,
+        public ?string $networkId = null,
     ) {}
 }

--- a/app/Services/HetznerServerService.php
+++ b/app/Services/HetznerServerService.php
@@ -55,6 +55,17 @@ final readonly class HetznerServerService implements ServerService
             $payload['user_data'] = $data->cloudInit;
         }
 
+        if (! $data->publicIp) {
+            $payload['public_net'] = [
+                'enable_ipv4' => false,
+                'enable_ipv6' => false,
+            ];
+        }
+
+        if ($data->networkId !== null) {
+            $payload['networks'] = [(int) $data->networkId];
+        }
+
         $response = Http::withToken($this->token)
             ->post('https://api.hetzner.cloud/v1/servers', $payload);
 
@@ -103,13 +114,16 @@ final readonly class HetznerServerService implements ServerService
      */
     private function mapServerData(array $server): ServerData
     {
+        $publicIpv4 = $server['public_net']['ipv4']['ip'] ?? null;
+        $privateIpv4 = $server['private_net'][0]['ip'] ?? null;
+
         return new ServerData(
             externalId: $server['id'],
             name: $server['name'],
             status: ServerStatus::fromHetzner($server['status']),
             type: $server['server_type']['name'] ?? '',
             region: $server['datacenter']['name'] ?? '',
-            ipv4: $server['public_net']['ipv4']['ip'] ?? null,
+            ipv4: $publicIpv4 ?? $privateIpv4,
             ipv6: $server['public_net']['ipv6']['ip'] ?? null,
         );
     }


### PR DESCRIPTION
## Summary

CP and worker nodes should not have public IPs per ADR-0004 network isolation.

- Add `publicIp` (bool, default true) and `networkId` (nullable string) to `CreateServerData`
- `HetznerServerService` sends `public_net: {enable_ipv4: false, enable_ipv6: false}` and `networks: [id]` when set
- `mapServerData` falls back to `private_net` IP when public IP is absent
- **Bastion**: public IP + private network (entry point)
- **CP nodes**: private network only
- **Worker nodes**: private network only

Architecture:
```
Internet → bastion (public IP) → SSH → all nodes (private only)
Internet → Hetzner LB (M2) → workers (private only)
```

## Test plan

- [ ] Full suite passes (696 tests)
- [ ] Pint passes
- [ ] Verified on Hetzner: bastion has public IP, CP/workers have only private IPs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Server instances can now be configured with or without public IP addresses
  * Improved network association capabilities for infrastructure servers
  * Enhanced IP address resolution for network-attached servers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->