### PR TITLE
docs: CAPI architecture ADRs and codebase annotations

### DIFF
--- a/app/Contracts/FirewallService.php
+++ b/app/Contracts/FirewallService.php
@@ -9,6 +9,9 @@ use App\Data\FirewallData;
 use App\Data\FirewallRuleData;
 use Illuminate\Support\Collection;
 
+/**
+ * @see ADR-0005, ADR-0009 — Write methods to be removed; refactoring to CloudManager driver pattern
+ */
 interface FirewallService
 {
     public function create(CreateFirewallData $data): FirewallData;

--- a/app/Contracts/NatGatewayService.php
+++ b/app/Contracts/NatGatewayService.php
@@ -6,6 +6,9 @@ namespace App\Contracts;
 
 use App\Data\NatGatewayConfigData;
 
+/**
+ * @see ADR-0005, ADR-0009 — Write methods to be removed; refactoring to CloudManager driver pattern
+ */
 interface NatGatewayService
 {
     /**

--- a/app/Contracts/NetworkService.php
+++ b/app/Contracts/NetworkService.php
@@ -8,6 +8,9 @@ use App\Data\CreateNetworkData;
 use App\Data\NetworkData;
 use Illuminate\Support\Collection;
 
+/**
+ * @see ADR-0005, ADR-0009 — Write methods to be removed; refactoring to CloudManager driver pattern
+ */
 interface NetworkService
 {
     public function create(CreateNetworkData $data): NetworkData;

--- a/app/Contracts/ServerService.php
+++ b/app/Contracts/ServerService.php
@@ -8,6 +8,9 @@ use App\Data\CreateServerData;
 use App\Data\ServerData;
 use Illuminate\Support\Collection;
 
+/**
+ * @see ADR-0005, ADR-0009 — Write methods to be removed; refactoring to CloudManager driver pattern
+ */
 interface ServerService
 {
     public function getAll(): Collection;

--- a/app/Contracts/SshKeyService.php
+++ b/app/Contracts/SshKeyService.php
@@ -7,6 +7,9 @@ namespace App\Contracts;
 use App\Data\SshKeyData;
 use Illuminate\Support\Collection;
 
+/**
+ * @see ADR-0005, ADR-0009 — Write methods to be removed; refactoring to CloudManager driver pattern
+ */
 interface SshKeyService
 {
     public function register(string $name, string $publicKey): SshKeyData;

--- a/app/Contracts/StepHandler.php
+++ b/app/Contracts/StepHandler.php
@@ -6,6 +6,9 @@ namespace App\Contracts;
 
 use App\Models\Infrastructure;
 
+/**
+ * @see ADR-0005 — Superseded by CAPI; scheduled for removal
+ */
 interface StepHandler
 {
     public function handle(Infrastructure $infrastructure): void;

--- a/app/Enums/ProvisioningPhase.php
+++ b/app/Enums/ProvisioningPhase.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace App\Enums;
 
+/**
+ * @see ADR-0005 — Superseded by CAPI; scheduled for removal
+ */
 enum ProvisioningPhase: string
 {
     case Infrastructure = 'infrastructure';

--- a/app/Enums/ProvisioningStep.php
+++ b/app/Enums/ProvisioningStep.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace App\Enums;
 
+/**
+ * @see ADR-0005 — Superseded by CAPI; scheduled for removal
+ */
 enum ProvisioningStep: string
 {
     // Infrastructure phase (steps 1-10)

--- a/app/Services/BastionSshExecutor.php
+++ b/app/Services/BastionSshExecutor.php
@@ -16,6 +16,9 @@ use Illuminate\Support\Facades\Storage;
 use RuntimeException;
 use Symfony\Component\Process\Process;
 
+/**
+ * @see ADR-0005 — Superseded by CAPI; scheduled for removal
+ */
 final readonly class BastionSshExecutor
 {
     /** @var Closure(list<string>): Process */

--- a/app/Services/CloudInitGenerator.php
+++ b/app/Services/CloudInitGenerator.php
@@ -8,6 +8,9 @@ use InvalidArgumentException;
 use RuntimeException;
 use Symfony\Component\Yaml\Yaml;
 
+/**
+ * @see ADR-0005 — Superseded by CAPI; scheduled for removal
+ */
 final readonly class CloudInitGenerator
 {
     public function __construct(

--- a/app/Services/CloudProviderFactory.php
+++ b/app/Services/CloudProviderFactory.php
@@ -13,6 +13,9 @@ use App\Contracts\SshKeyService;
 use App\Enums\CloudProviderType;
 use RuntimeException;
 
+/**
+ * @see ADR-0009 — To be replaced by CloudManager
+ */
 class CloudProviderFactory
 {
     public function makeServerService(CloudProviderType $type, ?string $token = null): ServerService

--- a/app/Services/SshKeyGenerator.php
+++ b/app/Services/SshKeyGenerator.php
@@ -9,6 +9,9 @@ use Closure;
 use RuntimeException;
 use Symfony\Component\Process\Process;
 
+/**
+ * @see ADR-0005 — Superseded by CAPI; scheduled for removal
+ */
 final readonly class SshKeyGenerator
 {
     /** @var Closure(list<string>): Process */

--- a/docs/adr/0002-architecture-overview.md
+++ b/docs/adr/0002-architecture-overview.md
@@ -156,3 +156,7 @@ Key configuration files:
 - Event sourcing for complex domain workflows
 - Caching strategy (Redis) for performance
 - Queue system for background jobs
+
+### Post-ADR-0005 Update (2026-04-01)
+
+The provider abstraction layer shifts from direct cloud API calls (creating VMs, networks, firewalls) to CAPI manifest generation and Kubernetes API interaction. The `CloudProviderFactory` is replaced by a `CloudManager` following Laravel's Manager/Driver pattern (ADR-0009). Provider service contracts are narrowed to read-only inventory queries. See ADR-0005 for details.

--- a/docs/adr/0003-multipass-local-cloud-provider.md
+++ b/docs/adr/0003-multipass-local-cloud-provider.md
@@ -166,3 +166,7 @@ management without significant additional tooling.
 
 - SSH key injection via cloud-init when creating Multipass VMs
 - Multipass network configuration for multi-VM clusters
+
+### Post-ADR-0005 Scope Clarification (2026-04-01)
+
+Multipass is scoped to **local workload clusters only** — for developer testing of application deployments on a real Kubernetes cluster. It is NOT used for bootstrapping the CAPI management cluster; `clusterctl init` with `kind` serves that role (ADR-0007). The Multipass driver will be narrowed to read-only inventory queries under the CloudManager pattern (ADR-0009).

--- a/docs/adr/0004-kubernetes-architecture-and-roadmap.md
+++ b/docs/adr/0004-kubernetes-architecture-and-roadmap.md
@@ -1,8 +1,9 @@
 ---
 adr:
   number: 4
-  status: proposed
+  status: superseded
   date: 2026-03-29
+  superseded_by: ADR-0005
   authors: [Francisco Barrento]
   tags: [kubernetes, infrastructure, architecture, roadmap, ansible, cilium, gateway-api]
   related: [ADR-0001, ADR-0002, ADR-0003]

--- a/docs/adr/0005-cluster-api-as-cluster-lifecycle-engine.md
+++ b/docs/adr/0005-cluster-api-as-cluster-lifecycle-engine.md
@@ -1,0 +1,151 @@
+---
+adr:
+  number: 5
+  status: proposed
+  date: 2026-04-01
+  authors: [Francisco Barrento]
+  tags: [kubernetes, capi, cluster-api, infrastructure, architecture]
+  related: [ADR-0004, ADR-0006, ADR-0007, ADR-0008]
+---
+
+# Adopt Cluster API (CAPI) as Cluster Lifecycle Engine
+
+## Context
+
+ADR-0004 established a self-managed provisioning pipeline: a 17-step state machine, permanent bastion servers, Ansible playbooks, SSH-based orchestration, and per-provider service contracts (`ServerService`, `SshKeyService`, `NetworkService`, `FirewallService`, `NatGatewayService`). While functional for deploying individual clusters, this architecture does not scale to a multi-tenant PaaS managing hundreds of clusters across providers.
+
+The core problems with the ADR-0004 approach:
+
+- **Kuven owns every line of provisioning logic** — SSH, cloud-init, Ansible, rollback, node health remediation, upgrades. Each is a feature Kuven must build and maintain.
+- **Day-2 operations are unbounded scope** — scaling, upgrades, node replacement, certificate rotation, etcd backups all require bespoke implementation per provider.
+- **The bastion is a single point of failure** — all cluster operations route through it. If lost, operations are blocked until rebuilt.
+- **Provider contracts couple Kuven to cloud API details** — Kuven directly manages VMs, networks, firewalls, and SSH keys through 6 service contracts with 3 provider implementations each.
+
+Cluster API (CAPI) is a Kubernetes-native project that provides declarative APIs for provisioning, upgrading, and operating Kubernetes clusters. Infrastructure providers (CAPH for Hetzner, CAPDO for DigitalOcean, CAPA for AWS) handle provider-specific resource management. CAPI's reconciliation loop handles day-2 operations automatically.
+
+## Decision
+
+Kuven adopts Cluster API (CAPI) as its cluster lifecycle engine. This supersedes ADR-0004.
+
+### What CAPI Owns
+
+- VM provisioning via infrastructure providers (CAPH, CAPDO, CAPA)
+- Node bootstrapping via bootstrap providers (kubeadm)
+- Control plane lifecycle via control plane providers (KubeadmControlPlane)
+- Machine health checks and automatic remediation
+- Rolling upgrades (Kubernetes version, machine images)
+- Scaling (MachineDeployment replicas)
+- Network, firewall, and SSH key management (handled internally by infrastructure providers)
+
+### What Kuven Owns
+
+- Developer UX — UI, API, CLI
+- Multi-tenancy — organization isolation, RBAC, billing
+- CAPI manifest generation — translating user intent into Cluster, MachineDeployment, and KubeadmControlPlane resources
+- Cluster status monitoring — polling CAPI conditions and surfacing to the UI
+- Kubeconfig management — retrieving and storing encrypted kubeconfigs
+- Add-on orchestration — CNI (Cilium), Gateway API, monitoring stacks via ClusterResourceSets
+- Management cluster operations — bootstrap, upgrades, health monitoring
+
+### Supported Infrastructure Providers
+
+| Provider | CAPI Provider | Status |
+|----------|--------------|--------|
+| Hetzner | CAPH (cluster-api-provider-hetzner) | M1 |
+| DigitalOcean | CAPDO (cluster-api-provider-digitalocean) | Roadmap |
+| AWS | CAPA (cluster-api-provider-aws) | Roadmap |
+
+Each workload cluster uses a single provider. No cross-provider node topologies.
+
+### Operational Model
+
+After the management cluster exists (see ADR-0007), all ongoing operations are pure HTTP calls to the Kubernetes API:
+
+1. Kuven generates CAPI manifests from user configuration
+2. Kuven applies manifests to the management cluster via a PHP Kubernetes client
+3. CAPI reconciles — provisions infrastructure, bootstraps nodes, installs components
+4. Kuven polls Cluster conditions (`Ready`, `InfrastructureReady`, `ControlPlaneReady`) for status
+
+This runs on standard Laravel Cloud queue workers with no binary dependencies. The PHP Kubernetes client makes HTTP calls to the management cluster API — no `kubectl`, `clusterctl`, or SSH required.
+
+### No Custom State Machine
+
+The `ProvisioningStep` enum (17 steps) and `ProvisioningPhase` enum from ADR-0004 are removed. CAPI's reconciliation loop replaces the state machine. Kuven maps CAPI's Cluster conditions directly to `InfrastructureStatus`:
+
+| CAPI Condition | InfrastructureStatus |
+|---------------|---------------------|
+| Provisioning (no Ready condition) | Provisioning |
+| Ready=True | Healthy |
+| Ready=False, reason=degraded | Degraded |
+| Ready=False, reason=error | Failed |
+| Cluster deleted | Destroyed |
+
+### Impact on Existing Codebase
+
+The following components from ADR-0004 become obsolete:
+
+- **Remove**: `ProvisioningStep` enum, `ProvisioningPhase` enum, `ProcessProvisioningStep` job
+- **Remove**: `BastionSshExecutor`, `CloudInitGenerator`, `SshKeyGenerator`
+- **Remove**: Write methods from provider contracts (`create()`, `delete()`, `register()`, `addRule()`)
+- **Remove**: Provisioning actions (`CreateBastion`, `RunAnsible`, `ScpToBastion`, `GenerateInventory`, `RetrieveKubeconfig`, `CreateControlPlaneNodes`, `CreateWorkerNodes`, `WaitForBastion`, `WaitForNodes`, etc.)
+- **Keep**: `InfrastructureStatus` enum (maps to CAPI conditions)
+- **Keep**: `CloudProviderType` enum (identifies provider for manifest generation)
+- **Keep**: Read-only query methods on provider contracts (`list()`, `find()`) — see ADR-0009
+- **Keep**: Models (`CloudProvider`, `Infrastructure`, `KubernetesCluster`, `Server`)
+
+### New Components
+
+- **CAPI manifest generation layer** — per-provider template generation for Cluster, MachineDeployment, KubeadmControlPlane, and infrastructure-specific resources
+- **PHP Kubernetes client integration** — for applying manifests and polling status
+- **Cluster status poller** — scheduled job that watches CAPI conditions and updates Kuven's database
+
+## Consequences
+
+### Positive
+
+- **Massive scope reduction** — CAPI providers handle VM provisioning, networking, SSH, node bootstrap, and day-2 operations. Kuven focuses on UX and multi-tenancy.
+- **Day-2 operations for free** — upgrades, scaling, machine health checks, node replacement are built into CAPI.
+- **Declarative model** — desired state reconciliation is more robust than a linear step-by-step pipeline.
+- **Provider ecosystem** — new cloud providers can be added by installing a CAPI provider, not by implementing 6 service contracts.
+- **No bastion SPOF** — CAPI operates from the management cluster, not a per-infrastructure bastion VM.
+
+### Negative
+
+- **Existing code loss** — ~2,500 lines of provisioning code (actions, contracts, services, test doubles) become obsolete.
+- **New dependency** — Kuven depends on CAPI and its provider ecosystem. CAPI version compatibility, provider maturity, and upstream bugs become Kuven's concern.
+- **Management cluster overhead** — requires operating a Kubernetes cluster just to manage other clusters.
+- **PHP Kubernetes client maturity** — PHP Kubernetes client libraries have less community support than Go or Python equivalents.
+- **CAPI learning curve** — the team must understand CAPI's resource model, conditions, and provider-specific CRDs.
+
+### Risks
+
+- **CAPI provider maturity** — CAPH and CAPDO are less mature than CAPA. Provider-specific bugs may require workarounds or upstream contributions.
+- **PHP K8s client limitations** — CAPI uses custom resources (CRDs). The PHP client must support applying arbitrary manifests, not just core Kubernetes resources.
+- **Management cluster availability** — if the management cluster goes down, no new clusters can be provisioned and status polling stops. Mitigation: standard Kubernetes HA (3 control plane nodes), monitoring, and alerting.
+- **CAPI version upgrades** — CAPI releases may require manifest format changes. Mitigation: version pinning and staged rollouts.
+
+## Compliance
+
+- All CAPI manifest generation must be tested with provider-specific fixture data
+- PHP Kubernetes client integration must include retry and timeout handling
+- Cluster status polling must not overwhelm the management cluster API — use appropriate intervals and watch semantics where supported
+- Existing provisioning code must be annotated with `@see ADR-0005` before removal
+
+## Notes
+
+### Alternatives Considered
+
+| Decision | Alternative | Reason rejected |
+|----------|-----------|----------------|
+| CAPI | Continue bastion/Ansible (ADR-0004) | Does not scale to multi-tenant PaaS; unbounded day-2 ops scope |
+| CAPI | Crossplane | Crossplane manages infrastructure but does not manage Kubernetes cluster lifecycle directly |
+| CAPI | Terraform via PHP | Adds a binary dependency; Terraform state management is complex in a multi-tenant context |
+| CAPI | Managed Kubernetes (EKS, GKE, DOKS) | Limits provider choice; different APIs per provider; no self-managed option |
+
+### PHP Kubernetes Client Candidates
+
+- `renoki-co/php-k8s` — actively maintained, supports CRD operations
+- `maclof/kubernetes-client` — simpler API, may lack CRD support
+- Raw HTTP client (Guzzle/Laravel HTTP) — maximum flexibility, no library dependency
+
+Evaluation is a prerequisite for implementation.

--- a/docs/adr/0006-managed-paas-tenant-responsibility-model.md
+++ b/docs/adr/0006-managed-paas-tenant-responsibility-model.md
@@ -1,0 +1,88 @@
+---
+adr:
+  number: 6
+  status: proposed
+  date: 2026-04-01
+  authors: [Francisco Barrento]
+  tags: [paas, tenancy, responsibility, architecture]
+  related: [ADR-0005, ADR-0007, ADR-0008]
+---
+
+# Kuven as Managed PaaS — Tenant Responsibility Model
+
+## Context
+
+With the adoption of CAPI (ADR-0005), Kuven needs a clear model for what the platform manages versus what tenants are responsible for. This decision shapes the entire product: pricing, onboarding, support surface, and the degree of Kubernetes knowledge required from tenants.
+
+Two models exist in the market:
+
+1. **Self-service toolkit** — tenants interact with cluster infrastructure directly (kubectl, dashboards, CAPI). Kuven is a management layer. Examples: Rancher, Lens.
+2. **Managed PaaS** — tenants never see Kubernetes internals. They describe what they want (a cluster, an app deployment) and the platform handles everything. Examples: Heroku, Render, Porter.
+
+## Decision
+
+Kuven is a **managed PaaS**. Tenants provide cloud provider credentials. Kuven operates the full cluster lifecycle on their behalf.
+
+### What Tenants Control
+
+- **Cloud provider credentials** — tenants connect their Hetzner, DigitalOcean, or AWS accounts. Kuven provisions workload clusters into the tenant's cloud account using their API tokens.
+- **Cluster configuration** — region, node count, machine sizes, Kubernetes version.
+- **Application deployments** — what runs on their clusters.
+- **Cloud spend** — workload cluster infrastructure costs are on the tenant's cloud account.
+
+### What Tenants Never See
+
+- CAPI resources, management cluster, or any Kubernetes control plane internals
+- `kubectl` access to the management cluster
+- CAPI manifests, CRDs, or reconciliation status
+- Infrastructure provider details (CAPH, CAPDO)
+
+### What Kuven Operates
+
+- **Management cluster** — Kuven's own infrastructure, invisible to tenants (ADR-0007)
+- **Cluster lifecycle** — provisioning, upgrades, scaling, health monitoring, node replacement
+- **Add-on management** — CNI (Cilium), ingress, monitoring, security policies
+- **Kubeconfig delivery** — tenants receive a scoped kubeconfig for their workload cluster if they need direct access
+
+### Credential Model
+
+Tenants register their cloud provider credentials through the Kuven UI. The existing `CloudProvider` model (with `organization_id` and encrypted `api_token`) continues to serve this purpose. Kuven uses these credentials when generating CAPI manifests — they are injected as Kubernetes Secrets in the tenant's namespace on the management cluster.
+
+Kuven never provisions resources on its own cloud accounts for tenants. Kuven's cloud accounts are used exclusively for the management cluster infrastructure.
+
+## Consequences
+
+### Positive
+
+- **Zero Kubernetes knowledge required** — tenants interact with a web UI, not Kubernetes APIs
+- **Clear billing model** — Kuven charges for the platform, cloud costs are on the tenant's account
+- **Reduced support surface** — tenants can't misconfigure CAPI resources or management cluster state
+- **Security boundary** — tenants have no access to the management cluster or other tenants' resources
+
+### Negative
+
+- **Less flexibility** — power users who want custom CAPI configurations or direct management cluster access cannot get it
+- **Trust requirement** — tenants must trust Kuven with their cloud provider API tokens
+- **Support burden** — Kuven is fully responsible for cluster health; failures are Kuven's problem, not the tenant's
+
+### Risks
+
+- **Credential security** — tenant API tokens stored in Kuven's database and as Kubernetes Secrets on the management cluster are high-value targets. Mitigation: encryption at rest, RBAC-scoped access (ADR-0008), audit logging.
+- **Blast radius** — a bug in Kuven's manifest generation could affect all tenants on a management cluster. Mitigation: staged rollouts, canary deployments for manifest changes.
+- **Vendor lock-in perception** — tenants may resist giving full operational control to Kuven. Mitigation: tenants own their cloud accounts and can always access their infrastructure directly.
+
+## Compliance
+
+- Kuven must never provision resources on the tenant's cloud account outside of what the tenant explicitly requested
+- Tenant API tokens must be encrypted at rest in both the database and Kubernetes Secrets
+- All operations on a tenant's behalf must be logged and auditable
+- The UI must clearly show which cloud account resources are provisioned in
+
+## Notes
+
+### Alternatives Considered
+
+| Decision | Alternative | Reason rejected |
+|----------|-----------|----------------|
+| Managed PaaS | Self-service toolkit (expose CAPI) | Increases support surface; requires tenants to understand Kubernetes; defeats the purpose of an IDP |
+| Tenant-owned credentials | Kuven-owned cloud accounts | Kuven would eat infrastructure costs; complicates billing; tenants lose direct cloud access |

--- a/docs/adr/0007-management-cluster-bootstrap-strategy.md
+++ b/docs/adr/0007-management-cluster-bootstrap-strategy.md
@@ -1,0 +1,117 @@
+---
+adr:
+  number: 7
+  status: proposed
+  date: 2026-04-01
+  authors: [Francisco Barrento]
+  tags: [kubernetes, capi, management-cluster, bootstrap, operations]
+  related: [ADR-0005, ADR-0006, ADR-0008]
+---
+
+# Management Cluster Bootstrap Strategy
+
+## Context
+
+CAPI requires a management cluster — a Kubernetes cluster that runs the CAPI controllers, infrastructure providers, and reconciliation loops. All tenant workload clusters are orchestrated from this management cluster.
+
+Key constraints:
+
+- **The management cluster is Kuven's infrastructure**, not a tenant's (ADR-0006). Tenants never know it exists.
+- **Kuven is deployed on Laravel Cloud**, which does not allow installing arbitrary binaries (`clusterctl`, `kind`, `kubectl`) in its containers.
+- **Bootstrap is rare** — one management cluster per region, provisioned once and operated for months or years.
+- **Ongoing operations** (applying CAPI manifests, polling status) are pure HTTP calls to the Kubernetes API, which run on standard Laravel Cloud queue workers with no binary dependencies.
+
+## Decision
+
+### Management Cluster Topology
+
+Kuven operates a **shared management cluster per region**. All tenants in a region share the same management cluster, isolated by Kubernetes namespace (ADR-0008).
+
+Starting configuration:
+
+| Component | Specification |
+|-----------|--------------|
+| Control plane | 3 nodes (HA) |
+| Provider | Kuven's own cloud account (Hetzner initially) |
+| CAPI providers installed | CAPH (Hetzner), additional providers as needed |
+| Expected scale | One management cluster serves all tenants in a region |
+
+Additional management clusters are added per-region as Kuven expands geographically.
+
+### Bootstrap via Local CLI
+
+The management cluster is bootstrapped by a Kuven operator running the `kuven init` Artisan command on a machine with the required tools installed:
+
+```
+kuven init --provider=hetzner --region=nuremberg
+```
+
+The command wraps the standard CAPI bootstrap flow:
+
+1. `kind create cluster` — creates a temporary local bootstrap cluster
+2. `clusterctl init --infrastructure hetzner` — installs CAPI controllers on the bootstrap cluster
+3. Apply Cluster manifest — CAPI provisions the real management cluster on Kuven's cloud account
+4. Wait for the management cluster to be ready
+5. `clusterctl move` — pivots CAPI state from the bootstrap cluster to the real management cluster
+6. Store the management cluster kubeconfig encrypted in Kuven's database
+7. `kind delete cluster` — destroys the temporary bootstrap cluster
+
+**Prerequisites on the operator's machine**: `clusterctl`, `kind`, `kubectl`, Docker.
+
+### Kubeconfig Storage
+
+The management cluster kubeconfig is stored encrypted in Kuven's database. Laravel Cloud queue workers retrieve it at runtime to make Kubernetes API calls. The kubeconfig is never exposed to tenants.
+
+### Management Cluster Lifecycle
+
+| Operation | How |
+|-----------|-----|
+| Bootstrap | `kuven init` (local CLI, one-time) |
+| CAPI provider upgrades | `clusterctl upgrade` (operator runs manually or via CI) |
+| Kubernetes upgrades | Standard CAPI self-managed upgrade flow |
+| Monitoring | Kuven health check job polls management cluster API |
+| Scaling | Add/remove nodes via CAPI MachineDeployment on the management cluster itself |
+
+## Consequences
+
+### Positive
+
+- **Simple bootstrap** — a single CLI command wraps the entire flow. No automated container orchestration needed for a rare operation.
+- **No Laravel Cloud constraints** — bootstrap runs locally where all tools are available. Ongoing operations are HTTP-only.
+- **Shared efficiency** — one management cluster per region avoids per-tenant control plane overhead.
+- **Standard CAPI flow** — `clusterctl init` + `clusterctl move` is the documented bootstrap pattern. Nothing custom.
+
+### Negative
+
+- **Manual operation** — bootstrap requires an operator with local tooling. Not self-service.
+- **Single management cluster per region** — if it goes down, all tenant operations in that region are blocked.
+- **Kubeconfig in database** — the management cluster credential is a high-value secret. Compromise gives access to all tenant CAPI resources.
+
+### Risks
+
+- **Management cluster failure** — loss of the management cluster blocks all provisioning and status polling. Mitigation: HA control plane (3 nodes), etcd backups, monitoring with alerting.
+- **Kubeconfig rotation** — the stored kubeconfig may expire or need rotation. Mitigation: use service account tokens with longer TTLs, or implement automatic rotation.
+- **CAPI scalability** — a single management cluster may hit limits with very large tenant counts. Mitigation: monitor CAPI controller resource usage, scale vertically before adding management clusters.
+
+## Compliance
+
+- The management cluster kubeconfig must be encrypted at rest in the database
+- `kuven init` must validate prerequisites (`clusterctl`, `kind`, `kubectl`, Docker) before starting
+- Management cluster health must be monitored via a scheduled Laravel job
+- Bootstrap procedures must be documented in a runbook alongside this ADR
+
+## Notes
+
+### Alternatives Considered
+
+| Decision | Alternative | Reason rejected |
+|----------|-----------|----------------|
+| Local CLI bootstrap | Automated bootstrap container (Docker/Fly.io/Fargate) | Over-engineering for a 1-3 time operation per region |
+| Shared management cluster | Per-tenant management cluster | Unnecessary overhead — tenants never see the management cluster. Adds cost and complexity with no user-facing benefit |
+| Kuven-owned cloud account | Management cluster on tenant infrastructure | Management cluster must be independent of any single tenant's billing, quotas, or account status |
+
+### Future Considerations
+
+- Automated bootstrap via CI/CD pipeline (GitHub Actions) if the number of regions grows significantly
+- Per-tenant management clusters for enterprise compliance requirements (hard isolation)
+- Multi-region management cluster federation

--- a/docs/adr/0008-tenant-isolation-via-rbac-scoped-namespaces.md
+++ b/docs/adr/0008-tenant-isolation-via-rbac-scoped-namespaces.md
@@ -1,0 +1,151 @@
+---
+adr:
+  number: 8
+  status: proposed
+  date: 2026-04-01
+  authors: [Francisco Barrento]
+  tags: [kubernetes, security, multi-tenancy, rbac, isolation]
+  related: [ADR-0005, ADR-0006, ADR-0007]
+---
+
+# Tenant Isolation via RBAC-Scoped Namespaces
+
+## Context
+
+Kuven operates a shared management cluster per region (ADR-0007). Multiple tenants' CAPI resources (Cluster objects, MachineDeployments, infrastructure provider resources) coexist on the same cluster. Tenant cloud provider credentials (API tokens) are stored as Kubernetes Secrets on the management cluster.
+
+This requires a strong isolation model. A failure in isolation means:
+
+- Tenant A could read tenant B's cloud provider credentials
+- Tenant A could modify or delete tenant B's clusters
+- A bug in Kuven could accidentally cross-contaminate operations
+
+Kubernetes namespaces alone are not a security boundary — they are an organizational mechanism. Without additional controls, any ServiceAccount with cluster-wide permissions can access all namespaces.
+
+## Decision
+
+Each tenant (Kuven organization) gets a dedicated namespace on the management cluster, with RBAC-enforced isolation.
+
+### Namespace Convention
+
+```
+kuven-org-{organization_id}
+```
+
+Example: `kuven-org-01HXK5P3M7NW8R9QZFY6D4BEGS`
+
+### Per-Tenant ServiceAccount
+
+When a tenant's organization is created in Kuven, the following resources are provisioned on the management cluster:
+
+1. **Namespace** — `kuven-org-{id}`
+2. **ServiceAccount** — `kuven-operator` in the tenant's namespace
+3. **Role** — full CAPI resource access scoped to the namespace only
+4. **RoleBinding** — binds the ServiceAccount to the Role
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: kuven-org-{id}
+  name: kuven-operator
+rules:
+  - apiGroups: ["cluster.x-k8s.io", "infrastructure.cluster.x-k8s.io", "bootstrap.cluster.x-k8s.io", "controlplane.cluster.x-k8s.io"]
+    resources: ["*"]
+    verbs: ["*"]
+  - apiGroups: [""]
+    resources: ["secrets", "configmaps"]
+    verbs: ["*"]
+```
+
+Kuven stores the ServiceAccount token for each tenant. When operating on a tenant's clusters, Kuven authenticates to the management cluster using the tenant's scoped ServiceAccount — not a cluster-admin credential.
+
+### Credential Storage
+
+Tenant cloud provider API tokens are stored as Kubernetes Secrets in the tenant's namespace. CAPI infrastructure providers read credentials from these Secrets when provisioning workload clusters. The RBAC Role ensures these Secrets are only accessible from within the tenant's namespace.
+
+### NetworkPolicies
+
+Default-deny NetworkPolicies are applied to each tenant namespace to prevent cross-namespace network access on the management cluster:
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  namespace: kuven-org-{id}
+  name: default-deny
+spec:
+  podSelector: {}
+  policyTypes: ["Ingress", "Egress"]
+```
+
+CAPI controller pods (which run in the `capi-system` namespace) are exempted via targeted policies.
+
+### ResourceQuotas
+
+Each tenant namespace gets a ResourceQuota to prevent a single tenant's CAPI operations from consuming excessive management cluster resources:
+
+```yaml
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  namespace: kuven-org-{id}
+  name: tenant-quota
+spec:
+  hard:
+    count/clusters.cluster.x-k8s.io: "10"
+    count/machinedeployments.cluster.x-k8s.io: "50"
+    count/secrets: "100"
+```
+
+Quotas are configurable per tenant (plan-based limits).
+
+### Kuven's Internal Credentials
+
+Kuven maintains two levels of management cluster access:
+
+| Credential | Scope | Used for |
+|-----------|-------|----------|
+| Cluster-admin kubeconfig | Full cluster access | Namespace/RBAC provisioning, CAPI controller management, management cluster upgrades |
+| Tenant ServiceAccount token | Single namespace | All tenant-scoped operations (apply manifests, poll status, manage secrets) |
+
+The cluster-admin kubeconfig is used only by `kuven init` and administrative operations. Day-to-day tenant operations use the scoped ServiceAccount.
+
+## Consequences
+
+### Positive
+
+- **Kubernetes-enforced isolation** — RBAC prevents cross-namespace access at the API server level. A bug in Kuven that accidentally targets the wrong namespace gets a 403, not a data leak.
+- **Principle of least privilege** — tenant operations use the minimum required permissions.
+- **Auditable** — Kubernetes audit logs capture all API calls per ServiceAccount, providing per-tenant audit trails.
+- **Quota protection** — no single tenant can starve the management cluster.
+
+### Negative
+
+- **Provisioning overhead** — every new organization requires creating a namespace, ServiceAccount, Role, RoleBinding, NetworkPolicy, and ResourceQuota on the management cluster.
+- **Token management** — ServiceAccount tokens must be stored, rotated, and potentially refreshed.
+- **CAPI controller access** — CAPI controllers need cross-namespace access to reconcile resources. This requires careful RBAC configuration for the controller ServiceAccounts.
+
+### Risks
+
+- **RBAC misconfiguration** — an overly permissive Role could grant cross-namespace access. Mitigation: Role definitions are templated and tested; never manually edited.
+- **CAPI controller privilege escalation** — CAPI controllers run with broad permissions by default. A compromised controller could access all tenant namespaces. Mitigation: monitor CAPI controller pods, restrict their RBAC to the minimum required, keep CAPI versions updated.
+- **Management cluster compromise** — if the management cluster itself is compromised, all tenant credentials are exposed regardless of namespace isolation. Mitigation: HA control plane, network-level access restrictions, regular security audits.
+
+## Compliance
+
+- Tenant namespace provisioning must be automated — triggered on organization creation in Kuven
+- RBAC Role definitions must be version-controlled and applied from templates
+- ServiceAccount tokens must be encrypted at rest in Kuven's database
+- Namespace deletion must cascade — destroying a tenant's namespace cleans up all CAPI resources
+- Regular audits of management cluster RBAC configurations
+
+## Notes
+
+### Alternatives Considered
+
+| Decision | Alternative | Reason rejected |
+|----------|-----------|----------------|
+| Namespace + RBAC | Per-tenant management cluster | Unnecessary cost and complexity — tenants never access the management cluster |
+| Namespace + RBAC | vCluster (virtual clusters) | Adds operational complexity; standard RBAC is sufficient when only Kuven accesses the management cluster |
+| Scoped ServiceAccounts | Single cluster-admin for all operations | Violates least privilege; a bug could affect any tenant |

--- a/docs/adr/0009-cloud-provider-driver-pattern.md
+++ b/docs/adr/0009-cloud-provider-driver-pattern.md
@@ -1,0 +1,155 @@
+---
+adr:
+  number: 9
+  status: proposed
+  date: 2026-04-01
+  authors: [Francisco Barrento]
+  tags: [architecture, cloud-provider, driver-pattern, extensibility]
+  related: [ADR-0003, ADR-0005]
+---
+
+# Cloud Provider Driver Pattern
+
+## Context
+
+With the adoption of CAPI (ADR-0005), provider service contracts lose their write methods — CAPI infrastructure providers handle resource creation and lifecycle. The remaining value is **read-only inventory queries**: listing servers, networks, firewalls, and SSH keys from a tenant's cloud account for dashboard visibility.
+
+The current architecture uses a `CloudProviderFactory` with explicit `make*()` methods for each service:
+
+```php
+$factory->makeServerService($token);
+$factory->makeSshKeyService($token);
+$factory->makeNetworkService($token);
+$factory->makeFirewallService($token);
+$factory->makeNatGatewayService($token);
+```
+
+This has scaling problems:
+
+- Adding a new resource type requires adding a new `make*()` method to the factory and every provider implementation
+- Adding a new provider requires implementing 6+ service interfaces
+- The factory knows about every service type — it's a god object
+- Third-party providers cannot be added without modifying the factory
+
+Laravel solves this pattern with Manager classes (DatabaseManager, CacheManager, SocialiteManager). Socialite specifically demonstrates how to support first-party drivers that ship with the package and third-party drivers installable as separate Composer packages.
+
+## Decision
+
+Replace `CloudProviderFactory` with a `CloudManager` that follows Laravel's Manager pattern.
+
+### Driver Interface
+
+```php
+interface CloudDriver
+{
+    public function servers(): ServerQuery;
+    public function networks(): NetworkQuery;
+    public function firewalls(): FirewallQuery;
+    public function sshKeys(): SshKeyQuery;
+}
+```
+
+Each query interface exposes read-only methods only:
+
+```php
+interface ServerQuery
+{
+    public function list(): Collection;
+    public function find(string $externalId): ?ServerData;
+}
+```
+
+### Manager Usage
+
+```php
+// Resolve by provider type
+app(CloudManager::class)->driver('hetzner')->servers()->list();
+
+// Resolve from a CloudProvider model
+app(CloudManager::class)->for($cloudProvider)->networks()->list();
+```
+
+The `for()` method reads the provider's type and injects the encrypted API token automatically.
+
+### Driver Registration
+
+First-party drivers (Hetzner, DigitalOcean, Multipass) are registered in the `CloudManager`:
+
+```php
+class CloudManager extends Manager
+{
+    public function createHetznerDriver(): CloudDriver { ... }
+    public function createDigitalOceanDriver(): CloudDriver { ... }
+    public function createMultipassDriver(): CloudDriver { ... }
+}
+```
+
+Third-party drivers are installable as separate Composer packages and registered via `CloudManager::extend()`:
+
+```php
+// In a service provider from a third-party package
+CloudManager::extend('aws', function ($app, $config) {
+    return new AwsCloudDriver($config['token']);
+});
+```
+
+This follows the exact pattern Socialite uses for third-party providers (`socialite-providers/providers`).
+
+### Token Validation
+
+The existing `CloudProviderService::validateToken()` method moves into the driver:
+
+```php
+interface CloudDriver
+{
+    public function validateToken(): bool;
+    public function servers(): ServerQuery;
+    // ...
+}
+```
+
+### Migration Path
+
+1. Introduce `CloudManager` and `CloudDriver` interface
+2. Migrate existing Hetzner, DigitalOcean, and Multipass service implementations to drivers
+3. Remove `CloudProviderFactory` and individual `make*()` methods
+4. Remove write methods from all service classes
+5. Update all call sites to use `CloudManager`
+
+## Consequences
+
+### Positive
+
+- **Laravel-native pattern** — developers already understand Manager/Driver from Cache, Queue, Mail, Filesystem, Socialite
+- **Extensible** — third-party providers are installable packages, no core code changes required
+- **Simpler interface** — one `CloudDriver` interface instead of 6 separate service contracts
+- **Read-only by design** — the new interfaces only expose query methods, preventing accidental writes
+- **Token injection** — the `for($cloudProvider)` method handles credential injection, eliminating token-passing boilerplate
+
+### Negative
+
+- **Migration effort** — existing factory and service implementations must be refactored
+- **Breaking change** — all call sites using `CloudProviderFactory` must be updated
+- **Third-party driver quality** — community-maintained drivers may lag behind API changes
+
+### Risks
+
+- **Driver interface stability** — changing the `CloudDriver` interface breaks all third-party drivers. Mitigation: design the interface carefully before publishing; version it.
+- **Provider API differences** — not all providers expose the same resource types. Mitigation: query interfaces return empty collections for unsupported resources rather than throwing.
+
+## Compliance
+
+- All drivers must implement the full `CloudDriver` interface
+- InMemory test doubles must be provided for first-party drivers
+- Third-party driver packages must follow a documented naming convention (e.g., `kuven/cloud-driver-aws`)
+- The `CloudDriver` interface must not include write methods — resource lifecycle is CAPI's responsibility (ADR-0005)
+
+## Notes
+
+### Alternatives Considered
+
+| Decision | Alternative | Reason rejected |
+|----------|-----------|----------------|
+| Manager/Driver pattern | Keep CloudProviderFactory | Factory doesn't support third-party extensions; grows with every new service type |
+| Manager/Driver pattern | Strategy pattern (no Manager) | Loses Laravel's built-in Manager infrastructure (config resolution, driver caching, `extend()`) |
+| Separate Composer packages | Monorepo drivers | Socialite model is well-understood; separate packages allow independent versioning |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -45,7 +45,12 @@ ADRs are immutable—once created, they are never edited. If a decision changes,
 | [ADR-0001](0001-adr-process.md) | Establish ADR Process | proposed | 2026-03-28 |
 | [ADR-0002](0002-architecture-overview.md) | Architecture Overview | proposed | 2026-03-28 |
 | [ADR-0003](0003-multipass-local-cloud-provider.md) | Multipass as Local Cloud Provider | proposed | 2026-03-28 |
-| [ADR-0004](0004-kubernetes-architecture-and-roadmap.md) | Kubernetes Architecture, Provisioning Pipeline, and Roadmap | proposed | 2026-03-29 |
+| [ADR-0004](0004-kubernetes-architecture-and-roadmap.md) | Kubernetes Architecture, Provisioning Pipeline, and Roadmap | superseded | 2026-03-29 |
+| [ADR-0005](0005-cluster-api-as-cluster-lifecycle-engine.md) | Adopt Cluster API as Cluster Lifecycle Engine | proposed | 2026-04-01 |
+| [ADR-0006](0006-managed-paas-tenant-responsibility-model.md) | Kuven as Managed PaaS — Tenant Responsibility Model | proposed | 2026-04-01 |
+| [ADR-0007](0007-management-cluster-bootstrap-strategy.md) | Management Cluster Bootstrap Strategy | proposed | 2026-04-01 |
+| [ADR-0008](0008-tenant-isolation-via-rbac-scoped-namespaces.md) | Tenant Isolation via RBAC-Scoped Namespaces | proposed | 2026-04-01 |
+| [ADR-0009](0009-cloud-provider-driver-pattern.md) | Cloud Provider Driver Pattern | proposed | 2026-04-01 |
 
 ## Related Documentation
 


### PR DESCRIPTION
## Summary

Captures the architectural decisions from the CAPI adoption discussion into 5 new ADRs, updates 2 existing ADRs, and annotates 12 PHP files for future cleanup.

**New ADRs:**
- **ADR-0005**: Adopt Cluster API as cluster lifecycle engine — supersedes ADR-0004's bastion/Ansible pipeline
- **ADR-0006**: Kuven as Managed PaaS — tenants provide credentials, Kuven operates full cluster lifecycle
- **ADR-0007**: Management cluster bootstrap — shared per region, bootstrapped via local CLI (`kuven init`)
- **ADR-0008**: Tenant isolation — RBAC-scoped namespaces with ServiceAccounts, NetworkPolicies, ResourceQuotas
- **ADR-0009**: Cloud provider driver pattern — `CloudManager` like Socialite, read-only query interfaces, third-party driver support

**Updated ADRs:**
- **ADR-0004**: Status changed to `superseded`
- **ADR-0002**: Note on provider abstraction shift to CAPI manifest generation
- **ADR-0003**: Multipass scoped to local workload clusters only

**Codebase annotations:**
- 12 files annotated with `@see ADR-0005` / `@see ADR-0009` (contracts, enums, services, factory)

## Test plan

- [x] No code changes — annotations only (PHPDoc comments)
- [x] `vendor/bin/pint --dirty` passes
- [x] 890 tests passing
- [ ] Review each ADR for accuracy and completeness

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated architecture documentation establishing Cluster API as the cluster lifecycle engine.
  * Added Architecture Decision Records (ADRs) defining management cluster bootstrap strategy, tenant isolation model via RBAC-scoped namespaces, and cloud provider driver pattern architecture.

* **Chores**
  * Marked legacy provisioning services and utilities for future deprecation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->