### PR TITLE
fix: prevent flaky slug collision in OrganizationFactory

### DIFF
--- a/database/factories/OrganizationFactory.php
+++ b/database/factories/OrganizationFactory.php
@@ -20,10 +20,11 @@ final class OrganizationFactory extends Factory
     public function definition(): array
     {
         $name = $this->faker->company();
+        $slug = str($name)->slug()->toString().'-'.$this->faker->unique()->numerify('########');
 
         return [
             'name' => $name,
-            'slug' => str($name)->slug()->toString(),
+            'slug' => $slug,
             'description' => $this->faker->paragraph(),
         ];
     }


### PR DESCRIPTION
## Summary

- `OrganizationFactory` derived slugs directly from `faker->company()`, which has a limited pool — under parallel test runs the same company name (and therefore slug) could be generated by two workers simultaneously, causing a `UNIQUE constraint failed: organizations.slug` error
- Appends a unique 8-digit numeric suffix to every generated slug, making collisions impossible regardless of parallelism

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced organization slug generation to ensure greater uniqueness through improved identifier formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->