### PR TITLE
refactor: align input focus with Stitch design, add Textarea component

### DIFF
--- a/resources/js/components/app-top-bar.tsx
+++ b/resources/js/components/app-top-bar.tsx
@@ -1,5 +1,6 @@
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
+import { Input } from '@/components/ui/input';
 import { UserMenuContent } from '@/components/user-menu-content';
 import { useInitials } from '@/hooks/use-initials';
 import { cn } from '@/lib/utils';
@@ -121,10 +122,10 @@ export function AppTopBar({ tabs }: { tabs?: TabItem[] }) {
                         {/* Search */}
                         <div className="relative w-64">
                             <Search className="text-muted-foreground/40 absolute left-3 top-1/2 size-3.5 -translate-y-1/2" />
-                            <input
+                            <Input
                                 type="text"
                                 placeholder="Search resources or settings..."
-                                className="bg-card border-border/15 text-foreground placeholder:text-muted-foreground/40 focus:ring-primary/30 focus:border-primary/30 w-full rounded-md border py-2 pl-9 pr-3 text-xs transition-all focus:ring-1 focus:outline-none"
+                                className="h-9 bg-card pl-9 text-xs"
                             />
                         </div>
 

--- a/resources/js/components/ui/input.tsx
+++ b/resources/js/components/ui/input.tsx
@@ -7,7 +7,7 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<'input'>>(
         <input
             type={type}
             className={cn(
-                'flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+                'flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/25 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
                 className,
             )}
             ref={ref}

--- a/resources/js/components/ui/textarea.tsx
+++ b/resources/js/components/ui/textarea.tsx
@@ -1,0 +1,22 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+const Textarea = React.forwardRef<
+  HTMLTextAreaElement,
+  React.ComponentProps<"textarea">
+>(({ className, ...props }, ref) => {
+  return (
+    <textarea
+      className={cn(
+        "flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-base placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/25 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        className
+      )}
+      ref={ref}
+      {...props}
+    />
+  )
+})
+Textarea.displayName = "Textarea"
+
+export { Textarea }

--- a/resources/js/pages/dev/components.tsx
+++ b/resources/js/pages/dev/components.tsx
@@ -7,6 +7,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Skeleton } from '@/components/ui/skeleton';
+import { Textarea } from '@/components/ui/textarea';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { useAppearance } from '@/hooks/use-appearance';
 import { Head } from '@inertiajs/react';
@@ -190,6 +191,15 @@ export default function Components() {
                         <div className="grid gap-2">
                             <Label htmlFor="disabled-input">Disabled</Label>
                             <Input id="disabled-input" placeholder="Cannot edit" disabled />
+                        </div>
+                        <div className="grid gap-2">
+                            <Label htmlFor="textarea-default">Textarea</Label>
+                            <Textarea id="textarea-default" placeholder="Enter a longer description..." />
+                        </div>
+                        <div className="grid gap-2">
+                            <Label htmlFor="textarea-error">Textarea with error</Label>
+                            <Textarea id="textarea-error" placeholder="Invalid content" className="border-destructive" />
+                            <p className="text-destructive text-sm">Description is too long.</p>
                         </div>
                     </div>
                 </Section>

--- a/resources/js/pages/organization-general-settings/edit.tsx
+++ b/resources/js/pages/organization-general-settings/edit.tsx
@@ -5,6 +5,7 @@ import { SettingsField, SettingsSection } from '@/components/settings-section';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
 import AppLayout from '@/layouts/app-layout';
 import OrganizationSettingsLayout from '@/layouts/organization-settings-layout';
 import { type Organization } from '@/types';
@@ -102,13 +103,12 @@ export default function EditOrganizationGeneralSettingsPage({ organization, can,
 
                         <SettingsField label="Description" description="A brief description of your organization." htmlFor="description">
                             <div className="w-[260px] space-y-2">
-                                <textarea
+                                <Textarea
                                     id="description"
                                     rows={4}
                                     value={detailsForm.data.description}
                                     onChange={(event) => detailsForm.setData('description', event.target.value)}
                                     disabled={!can.update || detailsForm.processing}
-                                    className="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring min-h-28 w-full rounded-md border px-3 py-2 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-hidden disabled:cursor-not-allowed disabled:opacity-50"
                                 />
                                 <InputError message={detailsForm.errors.description} />
                             </div>


### PR DESCRIPTION
## Summary

- **Input focus**: Replace ring-offset-2 gap with glow-only focus (ring-[3px] ring-ring/25). No gap between border and ring. Border color preserved for error state.
- **Textarea**: New shadcn component with same focus conventions as Input.
- **Header search**: Uses `<Input>` component instead of raw `<input>` with inline classes.
- **Org settings**: Replaces raw `<textarea>` with `<Textarea>` component.
- **Dev components**: Added textarea examples (default + error state).

## Test plan

- [x] `npm run build` succeeds
- [ ] Manual: focus input — subtle purple glow, no gap
- [ ] Manual: focus input with `border-destructive` — red border stays, glow appears
- [ ] Manual: dark mode — glow visible at 25% opacity
- [ ] Manual: header search input — same focus behavior as form inputs
- [ ] Manual: org settings textarea — same focus behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new Textarea component for consistent form input styling and behavior across the application.

* **UI/Style**
  * Updated focus ring styling for input fields to enhance visual feedback.
  * Streamlined search bar styling through shared input component migration.
  * Refined organization settings description field with improved textarea presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->