### PR TITLE
refactor: introduce typed Kubernetes manifest objects

### DIFF
--- a/app/Http/Integrations/Kubernetes/Contracts/ManifestContract.php
+++ b/app/Http/Integrations/Kubernetes/Contracts/ManifestContract.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Integrations\Kubernetes\Contracts;
+
+use App\Http\Integrations\Kubernetes\Enums\ApiVersion;
+use App\Http\Integrations\Kubernetes\Enums\Kind;
+
+interface ManifestContract
+{
+    public function apiVersion(): ApiVersion;
+
+    public function kind(): Kind;
+
+    public function resource(): string;
+
+    public function namespace(): ?string;
+
+    public function isClusterScoped(): bool;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array;
+}

--- a/app/Http/Integrations/Kubernetes/Enums/ApiVersion.php
+++ b/app/Http/Integrations/Kubernetes/Enums/ApiVersion.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Integrations\Kubernetes\Enums;
+
+enum ApiVersion: string
+{
+    case V1 = 'v1';
+    case AppsV1 = 'apps/v1';
+    case RbacAuthorizationV1 = 'rbac.authorization.k8s.io/v1';
+}

--- a/app/Http/Integrations/Kubernetes/Enums/Kind.php
+++ b/app/Http/Integrations/Kubernetes/Enums/Kind.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Integrations\Kubernetes\Enums;
+
+enum Kind: string
+{
+    case Deployment = 'Deployment';
+    case Namespace = 'Namespace';
+    case Role = 'Role';
+    case RoleBinding = 'RoleBinding';
+    case Secret = 'Secret';
+    case ServiceAccount = 'ServiceAccount';
+}

--- a/app/Http/Integrations/Kubernetes/Enums/SecretType.php
+++ b/app/Http/Integrations/Kubernetes/Enums/SecretType.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Integrations\Kubernetes\Enums;
+
+enum SecretType: string
+{
+    case DockerConfigJson = 'kubernetes.io/dockerconfigjson';
+    case Opaque = 'Opaque';
+    case Tls = 'kubernetes.io/tls';
+}

--- a/app/Http/Integrations/Kubernetes/Manifests/AnnotationSet.php
+++ b/app/Http/Integrations/Kubernetes/Manifests/AnnotationSet.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Integrations\Kubernetes\Manifests;
+
+final readonly class AnnotationSet
+{
+    /**
+     * @param  array<string, string>  $annotations
+     */
+    public function __construct(
+        public array $annotations = [],
+    ) {}
+
+    /**
+     * @return array<string, string>
+     */
+    public function toArray(): array
+    {
+        return $this->annotations;
+    }
+}

--- a/app/Http/Integrations/Kubernetes/Manifests/LabelSet.php
+++ b/app/Http/Integrations/Kubernetes/Manifests/LabelSet.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Integrations\Kubernetes\Manifests;
+
+final readonly class LabelSet
+{
+    /**
+     * @param  array<string, string>  $labels
+     */
+    public function __construct(
+        public array $labels = [],
+    ) {}
+
+    /**
+     * @return array<string, string>
+     */
+    public function toArray(): array
+    {
+        return $this->labels;
+    }
+}

--- a/app/Http/Integrations/Kubernetes/Manifests/ManifestMetadata.php
+++ b/app/Http/Integrations/Kubernetes/Manifests/ManifestMetadata.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Integrations\Kubernetes\Manifests;
+
+final readonly class ManifestMetadata
+{
+    public function __construct(public string $name, public ?string $namespace = null, public ?LabelSet $labels = new LabelSet(), public ?AnnotationSet $annotations = new AnnotationSet()) {}
+
+    /**
+     * @return array{name: string, namespace?: string, labels?: array<string, string>, annotations?: array<string, string>}
+     */
+    public function toArray(): array
+    {
+        $metadata = [
+            'name' => $this->name,
+        ];
+
+        if ($this->namespace !== null) {
+            $metadata['namespace'] = $this->namespace;
+        }
+
+        if ($this->labels->toArray() !== []) {
+            $metadata['labels'] = $this->labels->toArray();
+        }
+
+        if ($this->annotations->toArray() !== []) {
+            $metadata['annotations'] = $this->annotations->toArray();
+        }
+
+        return $metadata;
+    }
+}

--- a/app/Http/Integrations/Kubernetes/Manifests/NamespaceManifest.php
+++ b/app/Http/Integrations/Kubernetes/Manifests/NamespaceManifest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Integrations\Kubernetes\Manifests;
+
+use App\Http\Integrations\Kubernetes\Contracts\ManifestContract;
+use App\Http\Integrations\Kubernetes\Enums\ApiVersion;
+use App\Http\Integrations\Kubernetes\Enums\Kind;
+
+final readonly class NamespaceManifest implements ManifestContract
+{
+    public function __construct(
+        public ManifestMetadata $metadata,
+    ) {}
+
+    public function apiVersion(): ApiVersion
+    {
+        return ApiVersion::V1;
+    }
+
+    public function kind(): Kind
+    {
+        return Kind::Namespace;
+    }
+
+    public function resource(): string
+    {
+        return 'namespaces';
+    }
+
+    public function namespace(): ?string
+    {
+        return null;
+    }
+
+    public function isClusterScoped(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array{apiVersion: string, kind: string, metadata: array{name: string, namespace?: string, labels?: array<string, string>, annotations?: array<string, string>}}
+     */
+    public function toArray(): array
+    {
+        return [
+            'apiVersion' => $this->apiVersion()->value,
+            'kind' => $this->kind()->value,
+            'metadata' => $this->metadata->toArray(),
+        ];
+    }
+}

--- a/app/Http/Integrations/Kubernetes/Manifests/SecretManifest.php
+++ b/app/Http/Integrations/Kubernetes/Manifests/SecretManifest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Integrations\Kubernetes\Manifests;
+
+use App\Http\Integrations\Kubernetes\Contracts\ManifestContract;
+use App\Http\Integrations\Kubernetes\Enums\ApiVersion;
+use App\Http\Integrations\Kubernetes\Enums\Kind;
+use App\Http\Integrations\Kubernetes\Enums\SecretType;
+
+final readonly class SecretManifest implements ManifestContract
+{
+    public function __construct(
+        public ManifestMetadata $metadata,
+        public SecretStringData $data,
+        public SecretType|string $type = SecretType::Opaque,
+    ) {}
+
+    public function apiVersion(): ApiVersion
+    {
+        return ApiVersion::V1;
+    }
+
+    public function kind(): Kind
+    {
+        return Kind::Secret;
+    }
+
+    public function resource(): string
+    {
+        return 'secrets';
+    }
+
+    public function namespace(): ?string
+    {
+        return $this->metadata->namespace;
+    }
+
+    public function isClusterScoped(): bool
+    {
+        return false;
+    }
+
+    /**
+     * @return array{apiVersion: string, kind: string, metadata: array{name: string, namespace?: string, labels?: array<string, string>, annotations?: array<string, string>}, type: string, data: array<string, string>}
+     */
+    public function toArray(): array
+    {
+        return [
+            'apiVersion' => $this->apiVersion()->value,
+            'kind' => $this->kind()->value,
+            'metadata' => $this->metadata->toArray(),
+            'type' => $this->type instanceof SecretType ? $this->type->value : $this->type,
+            'data' => $this->data->toEncodedArray(),
+        ];
+    }
+}

--- a/app/Http/Integrations/Kubernetes/Manifests/SecretStringData.php
+++ b/app/Http/Integrations/Kubernetes/Manifests/SecretStringData.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Integrations\Kubernetes\Manifests;
+
+use SensitiveParameter;
+
+final readonly class SecretStringData
+{
+    /**
+     * @param  array<string, string>  $values
+     */
+    public function __construct(
+        #[SensitiveParameter] public array $values,
+    ) {}
+
+    /**
+     * @return array<string, string>
+     */
+    public function toEncodedArray(): array
+    {
+        $encodedValues = [];
+
+        foreach ($this->values as $key => $value) {
+            $encodedValues[$key] = base64_encode($value);
+        }
+
+        return $encodedValues;
+    }
+}

--- a/app/Http/Integrations/Kubernetes/Manifests/ServiceAccountManifest.php
+++ b/app/Http/Integrations/Kubernetes/Manifests/ServiceAccountManifest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Integrations\Kubernetes\Manifests;
+
+use App\Http\Integrations\Kubernetes\Contracts\ManifestContract;
+use App\Http\Integrations\Kubernetes\Enums\ApiVersion;
+use App\Http\Integrations\Kubernetes\Enums\Kind;
+
+final readonly class ServiceAccountManifest implements ManifestContract
+{
+    public function __construct(
+        public ManifestMetadata $metadata,
+    ) {}
+
+    public function apiVersion(): ApiVersion
+    {
+        return ApiVersion::V1;
+    }
+
+    public function kind(): Kind
+    {
+        return Kind::ServiceAccount;
+    }
+
+    public function resource(): string
+    {
+        return 'serviceaccounts';
+    }
+
+    public function namespace(): ?string
+    {
+        return $this->metadata->namespace;
+    }
+
+    public function isClusterScoped(): bool
+    {
+        return false;
+    }
+
+    /**
+     * @return array{apiVersion: string, kind: string, metadata: array{name: string, namespace?: string, labels?: array<string, string>, annotations?: array<string, string>}}
+     */
+    public function toArray(): array
+    {
+        return [
+            'apiVersion' => $this->apiVersion()->value,
+            'kind' => $this->kind()->value,
+            'metadata' => $this->metadata->toArray(),
+        ];
+    }
+}

--- a/app/Http/Integrations/Kubernetes/Requests/ApplyManifest.php
+++ b/app/Http/Integrations/Kubernetes/Requests/ApplyManifest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http\Integrations\Kubernetes\Requests;
 
+use App\Http\Integrations\Kubernetes\Contracts\ManifestContract;
 use App\Http\Integrations\Kubernetes\Data\ManifestData;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
@@ -30,18 +31,25 @@ final class ApplyManifest extends Request implements HasBody
      * @param  string|null  $resource  Explicit plural resource name (e.g. 'machinedeployments'). When null, derived as lowercase(kind)+'s'.
      */
     public function __construct(
-        private readonly array $manifest,
+        private readonly array|ManifestContract $manifest,
         private readonly ?string $resource = null,
     ) {}
 
     public function resolveEndpoint(): string
     {
-        $apiVersion = $this->manifest['apiVersion'];
-        $kind = $this->manifest['kind'];
-        $namespace = $this->manifest['metadata']['namespace'] ?? null;
-        $resource = $this->resource ?? mb_strtolower($kind).'s';
-
-        $isClusterScoped = in_array($kind, self::CLUSTER_SCOPED_KINDS, true) || $namespace === null;
+        if ($this->manifest instanceof ManifestContract) {
+            $apiVersion = $this->manifest->apiVersion()->value;
+            $kind = $this->manifest->kind()->value;
+            $namespace = $this->manifest->namespace();
+            $resource = $this->resource ?? $this->manifest->resource();
+            $isClusterScoped = $this->manifest->isClusterScoped();
+        } else {
+            $apiVersion = $this->manifest['apiVersion'];
+            $kind = $this->manifest['kind'];
+            $namespace = $this->manifest['metadata']['namespace'] ?? null;
+            $resource = $this->resource ?? mb_strtolower($kind).'s';
+            $isClusterScoped = in_array($kind, self::CLUSTER_SCOPED_KINDS, true) || $namespace === null;
+        }
 
         if (str_contains($apiVersion, '/')) {
             [$group, $version] = explode('/', $apiVersion, 2);
@@ -54,7 +62,7 @@ final class ApplyManifest extends Request implements HasBody
             return "{$base}/".rawurlencode($resource);
         }
 
-        return "{$base}/namespaces/".rawurlencode($namespace).'/'.rawurlencode($resource);
+        return "{$base}/namespaces/".rawurlencode((string) $namespace).'/'.rawurlencode($resource);
     }
 
     public function createDtoFromResponse(Response $response): ManifestData
@@ -67,6 +75,10 @@ final class ApplyManifest extends Request implements HasBody
      */
     protected function defaultBody(): array
     {
+        if ($this->manifest instanceof ManifestContract) {
+            return $this->manifest->toArray();
+        }
+
         return $this->manifest;
     }
 }

--- a/app/Http/Integrations/Kubernetes/Requests/CreateNamespace.php
+++ b/app/Http/Integrations/Kubernetes/Requests/CreateNamespace.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace App\Http\Integrations\Kubernetes\Requests;
 
 use App\Http\Integrations\Kubernetes\Data\NamespaceData;
+use App\Http\Integrations\Kubernetes\Manifests\ManifestMetadata;
+use App\Http\Integrations\Kubernetes\Manifests\NamespaceManifest;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
@@ -36,12 +38,8 @@ final class CreateNamespace extends Request implements HasBody
      */
     protected function defaultBody(): array
     {
-        return [
-            'apiVersion' => 'v1',
-            'kind' => 'Namespace',
-            'metadata' => [
-                'name' => $this->name,
-            ],
-        ];
+        return new NamespaceManifest(
+            metadata: new ManifestMetadata(name: $this->name),
+        )->toArray();
     }
 }

--- a/app/Http/Integrations/Kubernetes/Requests/CreateSecret.php
+++ b/app/Http/Integrations/Kubernetes/Requests/CreateSecret.php
@@ -5,6 +5,10 @@ declare(strict_types=1);
 namespace App\Http\Integrations\Kubernetes\Requests;
 
 use App\Http\Integrations\Kubernetes\Data\SecretData;
+use App\Http\Integrations\Kubernetes\Enums\SecretType;
+use App\Http\Integrations\Kubernetes\Manifests\ManifestMetadata;
+use App\Http\Integrations\Kubernetes\Manifests\SecretManifest;
+use App\Http\Integrations\Kubernetes\Manifests\SecretStringData;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
@@ -43,21 +47,13 @@ final class CreateSecret extends Request implements HasBody
      */
     protected function defaultBody(): array
     {
-        $encodedData = [];
-
-        foreach ($this->data as $key => $value) {
-            $encodedData[$key] = base64_encode($value);
-        }
-
-        return [
-            'apiVersion' => 'v1',
-            'kind' => 'Secret',
-            'metadata' => [
-                'name' => $this->name,
-                'namespace' => $this->namespace,
-            ],
-            'type' => $this->type,
-            'data' => $encodedData,
-        ];
+        return new SecretManifest(
+            metadata: new ManifestMetadata(
+                name: $this->name,
+                namespace: $this->namespace,
+            ),
+            data: new SecretStringData($this->data),
+            type: SecretType::tryFrom($this->type) ?? $this->type,
+        )->toArray();
     }
 }

--- a/app/Http/Integrations/Kubernetes/Requests/CreateServiceAccount.php
+++ b/app/Http/Integrations/Kubernetes/Requests/CreateServiceAccount.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace App\Http\Integrations\Kubernetes\Requests;
 
 use App\Http\Integrations\Kubernetes\Data\ServiceAccountData;
+use App\Http\Integrations\Kubernetes\Manifests\ManifestMetadata;
+use App\Http\Integrations\Kubernetes\Manifests\ServiceAccountManifest;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
@@ -37,13 +39,11 @@ final class CreateServiceAccount extends Request implements HasBody
      */
     protected function defaultBody(): array
     {
-        return [
-            'apiVersion' => 'v1',
-            'kind' => 'ServiceAccount',
-            'metadata' => [
-                'name' => $this->name,
-                'namespace' => $this->namespace,
-            ],
-        ];
+        return new ServiceAccountManifest(
+            metadata: new ManifestMetadata(
+                name: $this->name,
+                namespace: $this->namespace,
+            ),
+        )->toArray();
     }
 }

--- a/tests/Unit/Kubernetes/ApplyManifestTest.php
+++ b/tests/Unit/Kubernetes/ApplyManifestTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 use App\Http\Integrations\Kubernetes\Data\ManifestData;
 use App\Http\Integrations\Kubernetes\Data\ResourceMetadata;
 use App\Http\Integrations\Kubernetes\KubernetesConnector;
+use App\Http\Integrations\Kubernetes\Manifests\ManifestMetadata;
+use App\Http\Integrations\Kubernetes\Manifests\NamespaceManifest;
 use App\Http\Integrations\Kubernetes\Requests\ApplyManifest;
 use Saloon\Http\Faking\MockClient;
 use Saloon\Http\Faking\MockResponse;
@@ -76,11 +78,9 @@ it('resolves the correct endpoint for api group resources', function (): void {
 });
 
 it('resolves the correct endpoint for cluster-scoped resources', function (): void {
-    $manifest = [
-        'apiVersion' => 'v1',
-        'kind' => 'Namespace',
-        'metadata' => ['name' => 'my-namespace'],
-    ];
+    $manifest = new NamespaceManifest(
+        metadata: new ManifestMetadata(name: 'my-namespace'),
+    );
 
     $request = new ApplyManifest($manifest);
 
@@ -97,4 +97,27 @@ it('uses explicit resource name when provided', function (): void {
     $request = new ApplyManifest($manifest, resource: 'hetznerclusters');
 
     expect($request->resolveEndpoint())->toBe('/apis/infrastructure.cluster.x-k8s.io/v1beta1/namespaces/kuven-org-123/hetznerclusters');
+});
+
+it('applies a typed manifest to the kubernetes cluster', function (): void {
+    $connector = new KubernetesConnector(
+        server: 'https://127.0.0.1:60517',
+        token: 'test-token',
+        verifySsl: false,
+    );
+
+    $mockClient = new MockClient([
+        ApplyManifest::class => MockResponse::fixture('kubernetes/apply-manifest'),
+    ]);
+
+    $connector->withMockClient($mockClient);
+
+    $manifest = new NamespaceManifest(
+        metadata: new ManifestMetadata(name: 'kuven-test-ns'),
+    );
+
+    $response = $connector->send(new ApplyManifest($manifest));
+
+    expect($response->dtoOrFail())
+        ->toBeInstanceOf(ManifestData::class);
 });

--- a/tests/Unit/Kubernetes/ManifestObjectsTest.php
+++ b/tests/Unit/Kubernetes/ManifestObjectsTest.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Http\Integrations\Kubernetes\Enums\SecretType;
+use App\Http\Integrations\Kubernetes\Manifests\AnnotationSet;
+use App\Http\Integrations\Kubernetes\Manifests\LabelSet;
+use App\Http\Integrations\Kubernetes\Manifests\ManifestMetadata;
+use App\Http\Integrations\Kubernetes\Manifests\NamespaceManifest;
+use App\Http\Integrations\Kubernetes\Manifests\SecretManifest;
+use App\Http\Integrations\Kubernetes\Manifests\SecretStringData;
+use App\Http\Integrations\Kubernetes\Manifests\ServiceAccountManifest;
+
+it('serializes a namespace manifest', function (): void {
+    $manifest = new NamespaceManifest(
+        metadata: new ManifestMetadata(
+            name: 'kuven-test-ns',
+            labels: new LabelSet([
+                'app.kubernetes.io/managed-by' => 'kuven',
+            ]),
+            annotations: new AnnotationSet([
+                'kuven.io/environment' => 'test',
+            ]),
+        ),
+    );
+
+    expect($manifest->toArray())->toBe([
+        'apiVersion' => 'v1',
+        'kind' => 'Namespace',
+        'metadata' => [
+            'name' => 'kuven-test-ns',
+            'labels' => [
+                'app.kubernetes.io/managed-by' => 'kuven',
+            ],
+            'annotations' => [
+                'kuven.io/environment' => 'test',
+            ],
+        ],
+    ]);
+});
+
+it('serializes a service account manifest', function (): void {
+    $manifest = new ServiceAccountManifest(
+        metadata: new ManifestMetadata(
+            name: 'kuven-operator',
+            namespace: 'kuven-test-ns',
+        ),
+    );
+
+    expect($manifest->toArray())->toBe([
+        'apiVersion' => 'v1',
+        'kind' => 'ServiceAccount',
+        'metadata' => [
+            'name' => 'kuven-operator',
+            'namespace' => 'kuven-test-ns',
+        ],
+    ]);
+});
+
+it('exposes service account manifest routing metadata', function (): void {
+    $manifest = new ServiceAccountManifest(
+        metadata: new ManifestMetadata(
+            name: 'kuven-operator',
+            namespace: 'kuven-test-ns',
+        ),
+    );
+
+    expect($manifest->apiVersion()->value)->toBe('v1')
+        ->and($manifest->kind()->value)->toBe('ServiceAccount')
+        ->and($manifest->resource())->toBe('serviceaccounts')
+        ->and($manifest->namespace())->toBe('kuven-test-ns')
+        ->and($manifest->isClusterScoped())->toBeFalse();
+});
+
+it('serializes a secret manifest with encoded data', function (): void {
+    $manifest = new SecretManifest(
+        metadata: new ManifestMetadata(
+            name: 'hetzner-credentials',
+            namespace: 'kuven-test-ns',
+        ),
+        data: new SecretStringData([
+            'token' => 'hcloud-api-token-value',
+        ]),
+        type: SecretType::Opaque,
+    );
+
+    expect($manifest->toArray())->toBe([
+        'apiVersion' => 'v1',
+        'kind' => 'Secret',
+        'metadata' => [
+            'name' => 'hetzner-credentials',
+            'namespace' => 'kuven-test-ns',
+        ],
+        'type' => 'Opaque',
+        'data' => [
+            'token' => base64_encode('hcloud-api-token-value'),
+        ],
+    ]);
+});
+
+it('exposes secret manifest routing metadata', function (): void {
+    $manifest = new SecretManifest(
+        metadata: new ManifestMetadata(
+            name: 'hetzner-credentials',
+            namespace: 'kuven-test-ns',
+        ),
+        data: new SecretStringData([
+            'token' => 'hcloud-api-token-value',
+        ]),
+    );
+
+    expect($manifest->apiVersion()->value)->toBe('v1')
+        ->and($manifest->kind()->value)->toBe('Secret')
+        ->and($manifest->resource())->toBe('secrets')
+        ->and($manifest->namespace())->toBe('kuven-test-ns')
+        ->and($manifest->isClusterScoped())->toBeFalse();
+});
+
+it('supports custom secret type strings', function (): void {
+    $manifest = new SecretManifest(
+        metadata: new ManifestMetadata(
+            name: 'tls-cert',
+            namespace: 'kuven-test-ns',
+        ),
+        data: new SecretStringData([
+            'tls.crt' => 'cert',
+            'tls.key' => 'key',
+        ]),
+        type: 'custom.type/v1',
+    );
+
+    expect($manifest->toArray()['type'])->toBe('custom.type/v1');
+});


### PR DESCRIPTION
## Summary
- add Kubernetes manifest domain primitives (ManifestContract, ApiVersion, Kind, SecretType)
- add typed manifest value objects for metadata, labels/annotations, namespace, service account, and secret payloads
- update ApplyManifest to support typed manifests while keeping array compatibility for incremental migration
- refactor CreateNamespace, CreateServiceAccount, and CreateSecret to build request bodies through typed manifests
- add focused unit tests for manifest serialization, routing metadata, custom secret type strings, and typed apply path

## Testing
- vendor/bin/pint --dirty --format agent
- php artisan test --compact tests/Unit/Kubernetes
- vendor/bin/pest tests/Unit/Kubernetes/ManifestObjectsTest.php tests/Unit/Kubernetes/ApplyManifestTest.php --coverage-clover=/tmp/k8s-manifests-clover.xml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Kubernetes manifest object support for creating and applying namespaces, secrets, and service accounts with metadata, labels, and annotations.
  * Introduced typed manifest handling with improved validation and serialization.

* **Tests**
  * Added comprehensive unit tests for manifest object serialization and Kubernetes resource routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->