### PR TITLE
feat: structured Kubernetes API error handling

### DIFF
--- a/app/Http/Integrations/Kubernetes/Data/StatusData.php
+++ b/app/Http/Integrations/Kubernetes/Data/StatusData.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Integrations\Kubernetes\Data;
+
+use App\Http\Integrations\Kubernetes\Enums\StatusReason;
+
+final readonly class StatusData
+{
+    public function __construct(
+        public string $message,
+        public StatusReason $reason,
+        public int $code,
+        public ?string $group = null,
+        public ?string $resource = null,
+    ) {}
+
+    /**
+     * @param  array<string, mixed>  $response
+     */
+    public static function fromKubernetesResponse(array $response): self
+    {
+        return new self(
+            message: $response['message'] ?? 'Unknown error',
+            reason: StatusReason::tryFrom($response['reason'] ?? '') ?? StatusReason::Unknown,
+            code: $response['code'] ?? 0,
+            group: $response['details']['group'] ?? null,
+            resource: $response['details']['kind'] ?? null,
+        );
+    }
+}

--- a/app/Http/Integrations/Kubernetes/Enums/StatusReason.php
+++ b/app/Http/Integrations/Kubernetes/Enums/StatusReason.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Integrations\Kubernetes\Enums;
+
+enum StatusReason: string
+{
+    case AlreadyExists = 'AlreadyExists';
+    case BadRequest = 'BadRequest';
+    case Conflict = 'Conflict';
+    case Forbidden = 'Forbidden';
+    case Gone = 'Gone';
+    case InternalError = 'InternalError';
+    case Invalid = 'Invalid';
+    case MethodNotAllowed = 'MethodNotAllowed';
+    case NotFound = 'NotFound';
+    case ServerTimeout = 'ServerTimeout';
+    case ServiceUnavailable = 'ServiceUnavailable';
+    case TooManyRequests = 'TooManyRequests';
+    case Unauthorized = 'Unauthorized';
+    case Unknown = 'Unknown';
+}

--- a/app/Http/Integrations/Kubernetes/Exceptions/KubernetesStatusException.php
+++ b/app/Http/Integrations/Kubernetes/Exceptions/KubernetesStatusException.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Integrations\Kubernetes\Exceptions;
+
+use App\Http\Integrations\Kubernetes\Data\StatusData;
+use RuntimeException;
+
+final class KubernetesStatusException extends RuntimeException
+{
+    public function __construct(
+        public readonly StatusData $status,
+    ) {
+        parent::__construct($status->message, $status->code);
+    }
+}

--- a/app/Http/Integrations/Kubernetes/KubernetesConnector.php
+++ b/app/Http/Integrations/Kubernetes/KubernetesConnector.php
@@ -4,15 +4,22 @@ declare(strict_types=1);
 
 namespace App\Http\Integrations\Kubernetes;
 
+use App\Http\Integrations\Kubernetes\Data\StatusData;
+use App\Http\Integrations\Kubernetes\Exceptions\KubernetesStatusException;
+use JsonException;
 use Saloon\Contracts\Authenticator;
 use Saloon\Http\Auth\TokenAuthenticator;
 use Saloon\Http\Connector;
+use Saloon\Http\Response;
 use Saloon\Traits\Plugins\AcceptsJson;
+use Saloon\Traits\Plugins\AlwaysThrowOnErrors;
 use SensitiveParameter;
+use Throwable;
 
 final class KubernetesConnector extends Connector
 {
     use AcceptsJson;
+    use AlwaysThrowOnErrors;
 
     public function __construct(
         private readonly string $server,
@@ -23,6 +30,21 @@ final class KubernetesConnector extends Connector
     public function resolveBaseUrl(): string
     {
         return $this->server;
+    }
+
+    public function getRequestException(Response $response, ?Throwable $senderException): ?Throwable
+    {
+        try {
+            $body = $response->json();
+        } catch (JsonException) {
+            return null;
+        }
+
+        if (($body['kind'] ?? null) === 'Status' && ($body['status'] ?? null) === 'Failure') {
+            return new KubernetesStatusException(StatusData::fromKubernetesResponse($body));
+        }
+
+        return null;
     }
 
     protected function defaultAuth(): Authenticator

--- a/tests/Unit/Kubernetes/ErrorHandlingTest.php
+++ b/tests/Unit/Kubernetes/ErrorHandlingTest.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Http\Integrations\Kubernetes\Enums\StatusReason;
+use App\Http\Integrations\Kubernetes\Exceptions\KubernetesStatusException;
+use App\Http\Integrations\Kubernetes\KubernetesConnector;
+use App\Http\Integrations\Kubernetes\Manifests\ManifestMetadata;
+use App\Http\Integrations\Kubernetes\Manifests\NamespaceManifest;
+use App\Http\Integrations\Kubernetes\Requests\ApplyManifest;
+use App\Http\Integrations\Kubernetes\Requests\GetNamespace;
+use Saloon\Exceptions\Request\RequestException;
+use Saloon\Http\Faking\MockClient;
+use Saloon\Http\Faking\MockResponse;
+
+it('throws KubernetesStatusException on 409 AlreadyExists', function (): void {
+    $connector = new KubernetesConnector(
+        server: 'https://127.0.0.1:60517',
+        token: 'test-token',
+        verifySsl: false,
+    );
+
+    $mockClient = new MockClient([
+        ApplyManifest::class => MockResponse::make([
+            'apiVersion' => 'v1',
+            'kind' => 'Status',
+            'metadata' => [],
+            'status' => 'Failure',
+            'message' => 'namespaces "kuven-ns" already exists',
+            'reason' => 'AlreadyExists',
+            'details' => [
+                'name' => 'kuven-ns',
+                'kind' => 'namespaces',
+            ],
+            'code' => 409,
+        ], 409),
+    ]);
+
+    $connector->withMockClient($mockClient);
+
+    $manifest = new NamespaceManifest(
+        metadata: new ManifestMetadata(name: 'kuven-ns'),
+    );
+
+    expect(fn () => $connector->send(new ApplyManifest($manifest)))
+        ->toThrow(function (KubernetesStatusException $e): void {
+            expect($e->status->reason)->toBe(StatusReason::AlreadyExists)
+                ->and($e->getCode())->toBe(409)
+                ->and($e->status->resource)->toBe('namespaces');
+        });
+});
+
+it('throws KubernetesStatusException on 404 NotFound', function (): void {
+    $connector = new KubernetesConnector(
+        server: 'https://127.0.0.1:60517',
+        token: 'test-token',
+        verifySsl: false,
+    );
+
+    $mockClient = new MockClient([
+        GetNamespace::class => MockResponse::make([
+            'apiVersion' => 'v1',
+            'kind' => 'Status',
+            'metadata' => [],
+            'status' => 'Failure',
+            'message' => 'namespaces "missing" not found',
+            'reason' => 'NotFound',
+            'code' => 404,
+        ], 404),
+    ]);
+
+    $connector->withMockClient($mockClient);
+
+    expect(fn () => $connector->send(new GetNamespace('missing')))
+        ->toThrow(function (KubernetesStatusException $e): void {
+            expect($e->status->reason)->toBe(StatusReason::NotFound)
+                ->and($e->getCode())->toBe(404);
+        });
+});
+
+it('throws generic RequestException on non-Status error body', function (): void {
+    $connector = new KubernetesConnector(
+        server: 'https://127.0.0.1:60517',
+        token: 'test-token',
+        verifySsl: false,
+    );
+
+    $mockClient = new MockClient([
+        GetNamespace::class => MockResponse::make('Internal Server Error', 500),
+    ]);
+
+    $connector->withMockClient($mockClient);
+
+    expect(fn () => $connector->send(new GetNamespace('test')))
+        ->toThrow(RequestException::class);
+});
+
+it('throws generic RequestException on JSON error without Status kind', function (): void {
+    $connector = new KubernetesConnector(
+        server: 'https://127.0.0.1:60517',
+        token: 'test-token',
+        verifySsl: false,
+    );
+
+    $mockClient = new MockClient([
+        GetNamespace::class => MockResponse::make(['error' => 'something went wrong'], 500),
+    ]);
+
+    $connector->withMockClient($mockClient);
+
+    expect(fn () => $connector->send(new GetNamespace('test')))
+        ->toThrow(RequestException::class);
+});
+
+it('auto-throws on error responses without dtoOrFail', function (): void {
+    $connector = new KubernetesConnector(
+        server: 'https://127.0.0.1:60517',
+        token: 'test-token',
+        verifySsl: false,
+    );
+
+    $mockClient = new MockClient([
+        GetNamespace::class => MockResponse::make([
+            'apiVersion' => 'v1',
+            'kind' => 'Status',
+            'metadata' => [],
+            'status' => 'Failure',
+            'message' => 'forbidden',
+            'reason' => 'Forbidden',
+            'code' => 403,
+        ], 403),
+    ]);
+
+    $connector->withMockClient($mockClient);
+
+    // send() alone should throw — no dtoOrFail() needed
+    expect(fn () => $connector->send(new GetNamespace('test')))
+        ->toThrow(KubernetesStatusException::class);
+});

--- a/tests/Unit/Kubernetes/StatusDataTest.php
+++ b/tests/Unit/Kubernetes/StatusDataTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Http\Integrations\Kubernetes\Data\StatusData;
+use App\Http\Integrations\Kubernetes\Enums\StatusReason;
+use App\Http\Integrations\Kubernetes\Exceptions\KubernetesStatusException;
+
+it('parses a kubernetes status response', function (): void {
+    $data = StatusData::fromKubernetesResponse([
+        'apiVersion' => 'v1',
+        'kind' => 'Status',
+        'metadata' => [],
+        'status' => 'Failure',
+        'message' => 'deployments.apps "kuven-api" already exists',
+        'reason' => 'AlreadyExists',
+        'details' => [
+            'name' => 'kuven-api',
+            'group' => 'apps',
+            'kind' => 'deployments',
+        ],
+        'code' => 409,
+    ]);
+
+    expect($data->message)->toBe('deployments.apps "kuven-api" already exists')
+        ->and($data->reason)->toBe(StatusReason::AlreadyExists)
+        ->and($data->code)->toBe(409)
+        ->and($data->group)->toBe('apps')
+        ->and($data->resource)->toBe('deployments');
+});
+
+it('falls back to unknown for unrecognized status reasons', function (): void {
+    $data = StatusData::fromKubernetesResponse([
+        'message' => 'something unexpected',
+        'reason' => 'SomeFutureReason',
+        'code' => 500,
+    ]);
+
+    expect($data->reason)->toBe(StatusReason::Unknown)
+        ->and($data->group)->toBeNull()
+        ->and($data->resource)->toBeNull();
+});
+
+it('wraps status data in a kubernetes status exception', function (): void {
+    $status = StatusData::fromKubernetesResponse([
+        'message' => 'namespaces "kuven-ns" not found',
+        'reason' => 'NotFound',
+        'code' => 404,
+    ]);
+
+    $exception = new KubernetesStatusException($status);
+
+    expect($exception->getMessage())->toBe('namespaces "kuven-ns" not found')
+        ->and($exception->getCode())->toBe(404)
+        ->and($exception->status)->toBeInstanceOf(StatusData::class)
+        ->and($exception->status->reason)->toBe(StatusReason::NotFound);
+});


### PR DESCRIPTION
## Summary
- Introduce `StatusReason` backed string enum with 14 K8s error reasons (AlreadyExists, NotFound, Forbidden, etc.) plus `Unknown` fallback
- Add `StatusData` readonly DTO with `fromKubernetesResponse()` factory — parses K8s Status JSON into typed fields (message, reason, code, group, resource)
- Add `KubernetesStatusException` extending RuntimeException — carries `StatusData` so callers can match on `$e->status->reason`
- Wire up `KubernetesConnector` with `AlwaysThrowOnErrors` trait and `getRequestException()` override to auto-throw typed exceptions on K8s Status failure responses
- Gracefully handles non-JSON error bodies (falls back to generic `RequestException`)

Part of #124 (PR 2 of 6 — foundation for retry strategy, Server-Side Apply, and error tests)

## Test plan
- [x] 941 tests pass, 100% coverage
- [x] PHPStan level 5 clean
- [x] Rector clean
- [x] 8 new tests: StatusData parsing, unknown reason fallback, exception structure, 409/404/403 connector integration, non-JSON fallback, non-Status JSON fallback, AlwaysThrowOnErrors behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Kubernetes integration now provides enhanced error handling with detailed status information including specific error reasons, HTTP codes, affected resource details, and graceful fallback handling for unrecognized error types.

* **Tests**
  * Added comprehensive unit test coverage for Kubernetes error handling across various failure scenarios and response patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->