### PR TITLE
fix: add #[SensitiveParameter] to SecretData::$data

### DIFF
--- a/app/Http/Integrations/Kubernetes/Data/SecretData.php
+++ b/app/Http/Integrations/Kubernetes/Data/SecretData.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Http\Integrations\Kubernetes\Data;
 
+use SensitiveParameter;
+
 final readonly class SecretData
 {
     /**
@@ -12,7 +14,7 @@ final readonly class SecretData
     public function __construct(
         public ResourceMetadata $metadata,
         public string $type,
-        public array $data = [],
+        #[SensitiveParameter] public array $data = [],
     ) {}
 
     /**

--- a/tests/Unit/Kubernetes/CreateSecretTest.php
+++ b/tests/Unit/Kubernetes/CreateSecretTest.php
@@ -42,3 +42,9 @@ it('creates a secret on the kubernetes cluster', function (): void {
         ->and(mb_strlen((string) $data->metadata->uid))->toBeGreaterThan(0)
         ->and($data->metadata->creationTimestamp)->toBeInstanceOf(CarbonImmutable::class);
 });
+
+it('marks secret data as sensitive parameter', function (): void {
+    $param = new ReflectionParameter([SecretData::class, '__construct'], 'data');
+
+    expect($param->getAttributes(SensitiveParameter::class))->toHaveCount(1);
+});


### PR DESCRIPTION
## Summary
- Add `#[SensitiveParameter]` attribute to `SecretData::$data` to prevent decoded secret values from appearing in stack traces and error logs
- Add reflection test verifying the attribute is present

Part of #124 (PR 1 of 6)

## Test plan
- [x] Reflection test verifies attribute exists
- [x] All existing Kubernetes tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced data handling in Kubernetes integration by marking secret data with sensitivity attributes.

* **Tests**
  * Added validation tests to verify proper attribute application on sensitive data parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->