### PR TITLE
test: K8s error response and cluster-scoped array path coverage

### DIFF
--- a/tests/Unit/Kubernetes/ApplyManifestTest.php
+++ b/tests/Unit/Kubernetes/ApplyManifestTest.php
@@ -187,3 +187,27 @@ it('applies a typed manifest to the kubernetes cluster', function (): void {
     $mockClient->assertSent(fn ($currentRequest, $currentResponse): bool => $currentRequest instanceof ApplyManifest
         && $currentResponse->getPendingRequest()->body()?->all() === $manifest->toArray());
 });
+
+it('resolves cluster-scoped endpoint for raw namespace array', function (): void {
+    $manifest = [
+        'apiVersion' => 'v1',
+        'kind' => 'Namespace',
+        'metadata' => ['name' => 'kuven-test-ns'],
+    ];
+
+    $request = new ApplyManifest($manifest);
+
+    expect($request->resolveEndpoint())->toBe('/api/v1/namespaces');
+});
+
+it('resolves cluster-scoped endpoint for raw array without namespace', function (): void {
+    $manifest = [
+        'apiVersion' => 'v1',
+        'kind' => 'CustomKind',
+        'metadata' => ['name' => 'my-resource'],
+    ];
+
+    $request = new ApplyManifest($manifest);
+
+    expect($request->resolveEndpoint())->toBe('/api/v1/customkinds');
+});

--- a/tests/Unit/Kubernetes/DeleteNamespaceTest.php
+++ b/tests/Unit/Kubernetes/DeleteNamespaceTest.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+use App\Http\Integrations\Kubernetes\Enums\StatusReason;
+use App\Http\Integrations\Kubernetes\Exceptions\KubernetesStatusException;
 use App\Http\Integrations\Kubernetes\KubernetesConnector;
 use App\Http\Integrations\Kubernetes\Requests\DeleteNamespace;
 use Saloon\Http\Faking\MockClient;
@@ -24,4 +26,38 @@ it('deletes a namespace from the kubernetes cluster', function (): void {
 
     expect($response->successful())->toBeTrue();
     expect($response->json('status.phase'))->toBe('Terminating');
+});
+
+it('resolves the correct endpoint', function (): void {
+    $request = new DeleteNamespace('kuven-test-ns');
+
+    expect($request->resolveEndpoint())->toBe('/api/v1/namespaces/kuven-test-ns');
+});
+
+it('throws KubernetesStatusException when namespace not found', function (): void {
+    $connector = new KubernetesConnector(
+        server: 'https://127.0.0.1:60517',
+        token: 'test-token',
+        verifySsl: false,
+    );
+
+    $mockClient = new MockClient([
+        DeleteNamespace::class => MockResponse::make([
+            'apiVersion' => 'v1',
+            'kind' => 'Status',
+            'metadata' => [],
+            'status' => 'Failure',
+            'message' => 'namespaces "missing-ns" not found',
+            'reason' => 'NotFound',
+            'code' => 404,
+        ], 404),
+    ]);
+
+    $connector->withMockClient($mockClient);
+
+    expect(fn () => $connector->send(new DeleteNamespace('missing-ns')))
+        ->toThrow(function (KubernetesStatusException $e): void {
+            expect($e->status->reason)->toBe(StatusReason::NotFound)
+                ->and($e->getCode())->toBe(404);
+        });
 });


### PR DESCRIPTION
## Summary
- Add `DeleteNamespace` tests: endpoint resolution and 404 NotFound error path via `KubernetesStatusException`
- Add `ApplyManifest` tests: raw Namespace array exercises `CLUSTER_SCOPED_KINDS` path, raw array without namespace exercises implicit cluster-scoped detection

Part of #124 (PR 4 of 6)

## Test plan
- [x] 4 new tests covering previously untested paths
- [x] All 71 Kubernetes tests pass
- [x] Pint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added unit tests for manifest endpoint resolution with various configurations.
  * Added unit tests for namespace deletion request handling and error scenarios.

*Note: These changes are internal improvements with no direct impact on end-user functionality.*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->