### PR TITLE
fix: auth pages always visible, validation errors instead of 404

### DIFF
--- a/app/Http/Controllers/Auth/AuthenticatedSessionController.php
+++ b/app/Http/Controllers/Auth/AuthenticatedSessionController.php
@@ -11,6 +11,7 @@ use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Route;
+use Illuminate\Validation\ValidationException;
 use Inertia\Inertia;
 use Inertia\Response;
 use Laravel\Pennant\Feature;
@@ -22,20 +23,24 @@ final class AuthenticatedSessionController extends Controller
      */
     public function create(Request $request): Response
     {
-        abort_unless(Feature::active(LoginFeature::class), 404);
-
         return Inertia::render('auth/login', [
-            'canResetPassword' => Route::has('password.request'),
+            'canResetPassword' => Feature::active(LoginFeature::class) && Route::has('password.request'),
             'status' => $request->session()->get('status'),
         ]);
     }
 
     /**
      * Handle an incoming authentication request.
+     *
+     * @throws ValidationException
      */
     public function store(LoginRequest $request): RedirectResponse
     {
-        abort_unless(Feature::for($request->input('email'))->active(LoginFeature::class), 404);
+        if (! Feature::for($request->input('email'))->active(LoginFeature::class)) {
+            throw ValidationException::withMessages([
+                'email' => 'Login is not available yet. Join the waitlist at kuven.io for early access.',
+            ]);
+        }
 
         $request->authenticate();
 

--- a/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -13,6 +13,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Validation\Rules;
+use Illuminate\Validation\ValidationException;
 use Inertia\Inertia;
 use Inertia\Response;
 use Laravel\Pennant\Feature;
@@ -24,19 +25,21 @@ final class RegisteredUserController extends Controller
      */
     public function create(): Response
     {
-        abort_unless(Feature::active(RegistrationFeature::class), 404);
-
         return Inertia::render('auth/register');
     }
 
     /**
      * Handle an incoming registration request.
      *
-     * @throws \Illuminate\Validation\ValidationException
+     * @throws ValidationException
      */
     public function store(Request $request): RedirectResponse
     {
-        abort_unless(Feature::active(RegistrationFeature::class), 404);
+        if (! Feature::active(RegistrationFeature::class)) {
+            throw ValidationException::withMessages([
+                'email' => 'Registration is not available yet. Join the waitlist at kuven.io for early access.',
+            ]);
+        }
 
         $request->validate([
             'name' => 'required|string|max:255',

--- a/tests/Feature/Features/AuthFeatureGatesTest.php
+++ b/tests/Feature/Features/AuthFeatureGatesTest.php
@@ -7,42 +7,13 @@ use App\Features\RegistrationFeature;
 use App\Models\User;
 use Laravel\Pennant\Feature;
 
-test('registration page is accessible when feature is active', function (): void {
-    Feature::activate(RegistrationFeature::class);
-
-    $this->get('/register')->assertOk();
-});
-
-test('registration page returns 404 when feature is inactive', function (): void {
-    Feature::deactivate(RegistrationFeature::class);
-
-    $this->get('/register')->assertNotFound();
-});
-
-test('registration post returns 404 when feature is inactive', function (): void {
-    Feature::deactivate(RegistrationFeature::class);
-
-    $this->post('/register', [
-        'name' => 'Test',
-        'email' => 'test@example.com',
-        'password' => 'password',
-        'password_confirmation' => 'password',
-    ])->assertNotFound();
-});
-
-test('login page is accessible when feature is active', function (): void {
-    Feature::activate(LoginFeature::class);
+test('login page is always accessible', function (): void {
+    Feature::deactivate(LoginFeature::class);
 
     $this->get('/login')->assertOk();
 });
 
-test('login page returns 404 when feature is inactive', function (): void {
-    Feature::deactivate(LoginFeature::class);
-
-    $this->get('/login')->assertNotFound();
-});
-
-test('allowed email can login even when feature is inactive', function (): void {
+test('allowed email can login when feature is inactive', function (): void {
     Feature::deactivate(LoginFeature::class);
     config()->set('app.features.login_allowed_emails', ['francisco.barrento@gmail.com']);
 
@@ -59,7 +30,7 @@ test('allowed email can login even when feature is inactive', function (): void 
     $this->assertAuthenticated();
 });
 
-test('non-allowed email cannot login when feature is inactive', function (): void {
+test('non-allowed email gets validation error when feature is inactive', function (): void {
     Feature::for('other@example.com')->deactivate(LoginFeature::class);
     config()->set('app.features.login_allowed_emails', ['francisco.barrento@gmail.com']);
 
@@ -71,7 +42,45 @@ test('non-allowed email cannot login when feature is inactive', function (): voi
     $this->post('/login', [
         'email' => $user->email,
         'password' => 'password',
-    ])->assertNotFound();
+    ])->assertSessionHasErrors([
+        'email' => 'Login is not available yet. Join the waitlist at kuven.io for early access.',
+    ]);
+
+    $this->assertGuest();
+});
+
+test('registration page is always accessible', function (): void {
+    Feature::deactivate(RegistrationFeature::class);
+
+    $this->get('/register')->assertOk();
+});
+
+test('registration succeeds when feature is active', function (): void {
+    Feature::activate(RegistrationFeature::class);
+
+    $this->post('/register', [
+        'name' => 'Test User',
+        'email' => 'test@example.com',
+        'password' => 'password',
+        'password_confirmation' => 'password',
+    ])->assertRedirect();
+
+    $this->assertAuthenticated();
+});
+
+test('registration returns validation error when feature is inactive', function (): void {
+    Feature::deactivate(RegistrationFeature::class);
+
+    $this->post('/register', [
+        'name' => 'Test User',
+        'email' => 'test@example.com',
+        'password' => 'password',
+        'password_confirmation' => 'password',
+    ])->assertSessionHasErrors([
+        'email' => 'Registration is not available yet. Join the waitlist at kuven.io for early access.',
+    ]);
+
+    $this->assertGuest();
 });
 
 test('login feature resolves false in production', function (): void {


### PR DESCRIPTION
## Summary

Fixes the auth gates UX — pages are always visible, blocked actions return validation errors suggesting to join the waitlist instead of 404.

**Login:**
- GET `/login` always renders (users need to see the form)
- POST `/login` with non-allowed email returns: *"Login is not available yet. Join the waitlist at kuven.io for early access."*
- POST `/login` with allowed email works normally
- "Reset password" link hidden when login feature is off

**Registration:**
- GET `/register` always renders
- POST `/register` when inactive returns: *"Registration is not available yet. Join the waitlist at kuven.io for early access."*

## Test plan

- [x] 11 tests passing
- [ ] Manual: production — login page visible, non-allowed email shows validation error
- [ ] Manual: production — allowed email can log in
- [ ] Manual: production — register page visible, submit shows validation error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Login and registration pages are now always accessible, even when their respective features are disabled
  * Users receive validation error messages instead of 404 errors when attempting to use disabled features
  * Error messages now indicate feature availability status and reference relevant resources

<!-- end of auto-generated comment: release notes by coderabbit.ai -->