### PR TITLE
feat: add retry strategy to Kubernetes connector

### DIFF
--- a/app/Http/Integrations/Kubernetes/KubernetesConnector.php
+++ b/app/Http/Integrations/Kubernetes/KubernetesConnector.php
@@ -8,8 +8,11 @@ use App\Http\Integrations\Kubernetes\Data\StatusData;
 use App\Http\Integrations\Kubernetes\Exceptions\KubernetesStatusException;
 use JsonException;
 use Saloon\Contracts\Authenticator;
+use Saloon\Exceptions\Request\FatalRequestException;
+use Saloon\Exceptions\Request\RequestException;
 use Saloon\Http\Auth\TokenAuthenticator;
 use Saloon\Http\Connector;
+use Saloon\Http\Request;
 use Saloon\Http\Response;
 use Saloon\Traits\Plugins\AcceptsJson;
 use Saloon\Traits\Plugins\AlwaysThrowOnErrors;
@@ -20,6 +23,14 @@ final class KubernetesConnector extends Connector
 {
     use AcceptsJson;
     use AlwaysThrowOnErrors;
+
+    public ?int $tries = 3;
+
+    public ?int $retryInterval = 500;
+
+    public ?bool $useExponentialBackoff = true;
+
+    public ?bool $throwOnMaxTries = true;
 
     public function __construct(
         private readonly string $server,
@@ -45,6 +56,17 @@ final class KubernetesConnector extends Connector
         }
 
         return null;
+    }
+
+    public function handleRetry(FatalRequestException|RequestException $exception, Request $request): bool
+    {
+        if ($exception instanceof FatalRequestException) {
+            return true;
+        }
+
+        $status = $exception->getResponse()->status();
+
+        return in_array($status, [429, 503], true);
     }
 
     protected function defaultAuth(): Authenticator

--- a/tests/Unit/Kubernetes/RetryStrategyTest.php
+++ b/tests/Unit/Kubernetes/RetryStrategyTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Http\Integrations\Kubernetes\Exceptions\KubernetesStatusException;
+use App\Http\Integrations\Kubernetes\KubernetesConnector;
+use App\Http\Integrations\Kubernetes\Requests\GetNamespace;
+use Saloon\Exceptions\Request\FatalRequestException;
+use Saloon\Exceptions\Request\RequestException;
+use Saloon\Http\Faking\MockClient;
+use Saloon\Http\Faking\MockResponse;
+
+test('retries on 429 and succeeds on next attempt', function (): void {
+    $connector = new KubernetesConnector(
+        server: 'https://127.0.0.1:60517',
+        token: 'test-token',
+        verifySsl: false,
+    );
+
+    $mockClient = new MockClient([
+        MockResponse::make(['message' => 'Too Many Requests'], 429),
+        MockResponse::fixture('kubernetes/get-namespace'),
+    ]);
+
+    $connector->withMockClient($mockClient);
+
+    $response = $connector->send(new GetNamespace('kuven-test-ns'));
+
+    expect($response->successful())->toBeTrue();
+    $mockClient->assertSentCount(2);
+});
+
+test('retries on 503 and succeeds on next attempt', function (): void {
+    $connector = new KubernetesConnector(
+        server: 'https://127.0.0.1:60517',
+        token: 'test-token',
+        verifySsl: false,
+    );
+
+    $mockClient = new MockClient([
+        MockResponse::make(['message' => 'Service Unavailable'], 503),
+        MockResponse::fixture('kubernetes/get-namespace'),
+    ]);
+
+    $connector->withMockClient($mockClient);
+
+    $response = $connector->send(new GetNamespace('kuven-test-ns'));
+
+    expect($response->successful())->toBeTrue();
+    $mockClient->assertSentCount(2);
+});
+
+test('does not retry on 409 conflict', function (): void {
+    $connector = new KubernetesConnector(
+        server: 'https://127.0.0.1:60517',
+        token: 'test-token',
+        verifySsl: false,
+    );
+
+    $mockClient = new MockClient([
+        MockResponse::make([
+            'apiVersion' => 'v1',
+            'kind' => 'Status',
+            'metadata' => [],
+            'status' => 'Failure',
+            'message' => 'already exists',
+            'reason' => 'AlreadyExists',
+            'code' => 409,
+        ], 409),
+    ]);
+
+    $connector->withMockClient($mockClient);
+
+    expect(fn () => $connector->send(new GetNamespace('test')))
+        ->toThrow(KubernetesStatusException::class);
+
+    $mockClient->assertSentCount(1);
+});
+
+test('throws after max retries exhausted', function (): void {
+    $connector = new KubernetesConnector(
+        server: 'https://127.0.0.1:60517',
+        token: 'test-token',
+        verifySsl: false,
+    );
+
+    $mockClient = new MockClient([
+        MockResponse::make(['message' => 'Too Many Requests'], 429),
+        MockResponse::make(['message' => 'Too Many Requests'], 429),
+        MockResponse::make(['message' => 'Too Many Requests'], 429),
+    ]);
+
+    $connector->withMockClient($mockClient);
+
+    expect(fn () => $connector->send(new GetNamespace('test')))
+        ->toThrow(RequestException::class);
+
+    $mockClient->assertSentCount(3);
+});
+
+test('retries on connection failure', function (): void {
+    $connector = new KubernetesConnector(
+        server: 'https://127.0.0.1:60517',
+        token: 'test-token',
+        verifySsl: false,
+    );
+
+    $exception = new FatalRequestException(new Exception('Connection refused'), $connector->createPendingRequest(new GetNamespace('test')));
+
+    expect($connector->handleRetry($exception, new GetNamespace('test')))->toBeTrue();
+});


### PR DESCRIPTION
## Summary
- Configure 3 retries with 500ms exponential backoff on the `KubernetesConnector`
- Retries on 429 (rate limiting), 503 (apiserver overload), and `FatalRequestException` (connection failures)
- Non-transient errors (4xx) fail immediately without retries
- Base `Connector` already uses `HasTries` — we override properties and `handleRetry()` only

Part of #124 (PR 5 of 6)

## Test plan
- [x] 976 tests pass, 100% coverage
- [x] PHPStan clean, Rector clean, Pint clean
- [x] 5 new tests: retry on 429, retry on 503, no retry on 409, max retries exhausted, connection failure retry

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Kubernetes connector now supports configurable retry behavior with adjustable retry attempts, intervals, and exponential backoff. Automatically handles rate-limit and service unavailability errors for improved connection resilience.

* **Tests**
  * Added comprehensive test coverage for retry strategies, error handling scenarios, and failure conditions to ensure robust behavior under adverse conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->