### PR TITLE
feat: bootstrap cluster, CAPI installer, and kubeconfig storage actions

### DIFF
--- a/app/Actions/CreateBootstrapCluster.php
+++ b/app/Actions/CreateBootstrapCluster.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions;
+
+use App\Contracts\BootstrapClusterService;
+
+final readonly class CreateBootstrapCluster
+{
+    public function __construct(
+        private BootstrapClusterService $service,
+    ) {}
+
+    public function handle(string $name): void
+    {
+        if ($this->service->exists($name)) {
+            return;
+        }
+
+        $this->service->create($name);
+    }
+}

--- a/app/Actions/InstallCapiControllers.php
+++ b/app/Actions/InstallCapiControllers.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions;
+
+use App\Contracts\CapiInstallerService;
+
+final readonly class InstallCapiControllers
+{
+    public function __construct(
+        private CapiInstallerService $service,
+    ) {}
+
+    public function handle(string $provider, string $kubeconfig): void
+    {
+        $this->service->init($provider, $kubeconfig);
+    }
+}

--- a/app/Actions/StoreManagementKubeconfig.php
+++ b/app/Actions/StoreManagementKubeconfig.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions;
+
+use App\Contracts\KubeconfigReaderService;
+use App\Models\ManagementCluster;
+
+final readonly class StoreManagementKubeconfig
+{
+    public function __construct(
+        private KubeconfigReaderService $reader,
+    ) {}
+
+    public function handle(ManagementCluster $cluster, string $clusterName): void
+    {
+        $kubeconfig = $this->reader->read($clusterName);
+
+        $cluster->forceFill(['kubeconfig' => $kubeconfig])->save();
+    }
+}

--- a/app/Contracts/BootstrapClusterService.php
+++ b/app/Contracts/BootstrapClusterService.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Contracts;
+
+interface BootstrapClusterService
+{
+    public function create(string $name): void;
+
+    public function destroy(string $name): void;
+
+    public function exists(string $name): bool;
+}

--- a/app/Contracts/CapiInstallerService.php
+++ b/app/Contracts/CapiInstallerService.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Contracts;
+
+interface CapiInstallerService
+{
+    public function init(string $provider, string $kubeconfig): void;
+}

--- a/app/Contracts/KubeconfigReaderService.php
+++ b/app/Contracts/KubeconfigReaderService.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Contracts;
+
+interface KubeconfigReaderService
+{
+    public function read(string $clusterName): string;
+}

--- a/app/Services/InMemory/InMemoryBootstrapClusterService.php
+++ b/app/Services/InMemory/InMemoryBootstrapClusterService.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\InMemory;
+
+use App\Contracts\BootstrapClusterService;
+
+final class InMemoryBootstrapClusterService implements BootstrapClusterService
+{
+    /** @var list<string> */
+    private array $clusters = [];
+
+    private int $createCount = 0;
+
+    public function addCluster(string $name): self
+    {
+        if (! in_array($name, $this->clusters, true)) {
+            $this->clusters[] = $name;
+        }
+
+        return $this;
+    }
+
+    public function create(string $name): void
+    {
+        $this->createCount++;
+        $this->clusters[] = $name;
+    }
+
+    public function destroy(string $name): void
+    {
+        $this->clusters = array_values(array_filter(
+            $this->clusters,
+            fn (string $cluster): bool => $cluster !== $name,
+        ));
+    }
+
+    public function exists(string $name): bool
+    {
+        return in_array($name, $this->clusters, true);
+    }
+
+    public function createCount(): int
+    {
+        return $this->createCount;
+    }
+}

--- a/app/Services/InMemory/InMemoryCapiInstallerService.php
+++ b/app/Services/InMemory/InMemoryCapiInstallerService.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\InMemory;
+
+use App\Contracts\CapiInstallerService;
+use RuntimeException;
+
+final class InMemoryCapiInstallerService implements CapiInstallerService
+{
+    /** @var list<array{provider: string, kubeconfig: string}> */
+    private array $installations = [];
+
+    private bool $shouldFail = false;
+
+    public function shouldFail(bool $fail = true): self
+    {
+        $this->shouldFail = $fail;
+
+        return $this;
+    }
+
+    public function init(string $provider, string $kubeconfig): void
+    {
+        if ($this->shouldFail) {
+            throw new RuntimeException('Simulated CAPI installation failure');
+        }
+
+        $this->installations[] = [
+            'provider' => $provider,
+            'kubeconfig' => $kubeconfig,
+        ];
+    }
+
+    /** @return list<array{provider: string, kubeconfig: string}> */
+    public function installations(): array
+    {
+        return $this->installations;
+    }
+}

--- a/app/Services/InMemory/InMemoryKubeconfigReaderService.php
+++ b/app/Services/InMemory/InMemoryKubeconfigReaderService.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\InMemory;
+
+use App\Contracts\KubeconfigReaderService;
+use RuntimeException;
+
+final class InMemoryKubeconfigReaderService implements KubeconfigReaderService
+{
+    /** @var array<string, string> */
+    private array $kubeconfigs = [];
+
+    public function setKubeconfig(string $clusterName, string $kubeconfig): self
+    {
+        $this->kubeconfigs[$clusterName] = $kubeconfig;
+
+        return $this;
+    }
+
+    public function read(string $clusterName): string
+    {
+        return $this->kubeconfigs[$clusterName]
+            ?? throw new RuntimeException("No kubeconfig found for cluster '{$clusterName}'");
+    }
+}

--- a/tests/Unit/Actions/CreateBootstrapClusterTest.php
+++ b/tests/Unit/Actions/CreateBootstrapClusterTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\CreateBootstrapCluster;
+use App\Contracts\BootstrapClusterService;
+use App\Services\InMemory\InMemoryBootstrapClusterService;
+
+beforeEach(function (): void {
+    $this->service = new InMemoryBootstrapClusterService;
+    $this->app->instance(BootstrapClusterService::class, $this->service);
+    $this->action = $this->app->make(CreateBootstrapCluster::class);
+});
+
+test('creates a bootstrap cluster',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        $this->action->handle('kuven-mgmt');
+
+        expect($this->service->exists('kuven-mgmt'))->toBeTrue();
+    });
+
+test('skips creation if cluster already exists',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        $this->service->addCluster('kuven-mgmt');
+
+        $this->action->handle('kuven-mgmt');
+
+        expect($this->service->exists('kuven-mgmt'))->toBeTrue()
+            ->and($this->service->createCount())->toBe(0);
+    });
+
+test('destroys a bootstrap cluster',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        $this->service->addCluster('kuven-mgmt');
+
+        $this->service->destroy('kuven-mgmt');
+
+        expect($this->service->exists('kuven-mgmt'))->toBeFalse();
+    });

--- a/tests/Unit/Actions/InstallCapiControllersTest.php
+++ b/tests/Unit/Actions/InstallCapiControllersTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\InstallCapiControllers;
+use App\Contracts\CapiInstallerService;
+use App\Services\InMemory\InMemoryCapiInstallerService;
+
+beforeEach(function (): void {
+    $this->service = new InMemoryCapiInstallerService;
+    $this->app->instance(CapiInstallerService::class, $this->service);
+    $this->action = $this->app->make(InstallCapiControllers::class);
+});
+
+test('installs capi controllers for a provider',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        $this->action->handle('docker', '/tmp/kubeconfig');
+
+        expect($this->service->installations())->toHaveCount(1)
+            ->and($this->service->installations()[0]['provider'])->toBe('docker')
+            ->and($this->service->installations()[0]['kubeconfig'])->toBe('/tmp/kubeconfig');
+    });
+
+test('throws when capi installation fails',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        $this->service->shouldFail();
+
+        expect(fn () => $this->action->handle('docker', '/tmp/kubeconfig'))
+            ->toThrow(RuntimeException::class, 'Simulated CAPI installation failure');
+    });

--- a/tests/Unit/Actions/StoreManagementKubeconfigTest.php
+++ b/tests/Unit/Actions/StoreManagementKubeconfigTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\StoreManagementKubeconfig;
+use App\Contracts\KubeconfigReaderService;
+use App\Models\ManagementCluster;
+use App\Services\InMemory\InMemoryKubeconfigReaderService;
+use Illuminate\Support\Facades\DB;
+
+beforeEach(function (): void {
+    $this->reader = new InMemoryKubeconfigReaderService;
+    $this->app->instance(KubeconfigReaderService::class, $this->reader);
+    $this->action = $this->app->make(StoreManagementKubeconfig::class);
+});
+
+test('reads kubeconfig and stores it encrypted on management cluster',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        $kubeconfig = 'apiVersion: v1\nclusters:\n- cluster:\n    server: https://127.0.0.1:6443';
+
+        $this->reader->setKubeconfig('kuven-mgmt', $kubeconfig);
+
+        /** @var ManagementCluster $cluster */
+        $cluster = ManagementCluster::factory()->create();
+
+        $this->action->handle($cluster, 'kuven-mgmt');
+
+        $cluster->refresh();
+
+        expect($cluster->kubeconfig)->toBe($kubeconfig);
+
+        $raw = DB::table('management_clusters')
+            ->where('id', $cluster->id)
+            ->value('kubeconfig');
+
+        expect($raw)->not->toBe($kubeconfig);
+    });
+
+test('throws when kubeconfig is not available for cluster',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var ManagementCluster $cluster */
+        $cluster = ManagementCluster::factory()->create();
+
+        expect(fn () => $this->action->handle($cluster, 'nonexistent'))
+            ->toThrow(RuntimeException::class, "No kubeconfig found for cluster 'nonexistent'");
+    });


### PR DESCRIPTION
## Summary
- **CreateBootstrapCluster** action: creates a kind cluster via `BootstrapClusterService`, skips if already exists
- **InstallCapiControllers** action: runs `clusterctl init` via `CapiInstallerService`
- **StoreManagementKubeconfig** action: reads kubeconfig via `KubeconfigReaderService`, stores encrypted on `ManagementCluster` model
- Three contracts with InMemory test doubles following existing codebase pattern

Closes #140 — Part 2 of 3 for #107

## Test plan
- [x] 999 tests pass, 100% coverage
- [x] 7 new tests: create cluster, skip existing, destroy, install CAPI, install failure, store kubeconfig encrypted, missing kubeconfig error
- [x] `composer test` fully green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cluster bootstrap operations with creation, validation, and deletion capabilities
  * CAPI controller installation functionality
  * Kubeconfig management and storage operations

* **Tests**
  * Added comprehensive unit tests covering bootstrap, installation, and kubeconfig features

<!-- end of auto-generated comment: release notes by coderabbit.ai -->