### PR TITLE
feat: kuven:init command — management cluster bootstrap

### DIFF
--- a/app/Actions/CreateManagementCluster.php
+++ b/app/Actions/CreateManagementCluster.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions;
+
+use App\Data\CreateManagementClusterData;
+use App\Enums\ManagementClusterStatus;
+use App\Models\ManagementCluster;
+
+final class CreateManagementCluster
+{
+    public function handle(CreateManagementClusterData $data): ManagementCluster
+    {
+        return ManagementCluster::query()->create([
+            'name' => $data->name,
+            'provider' => $data->provider,
+            'region' => $data->region,
+            'status' => ManagementClusterStatus::Bootstrapping,
+        ]);
+    }
+}

--- a/app/Actions/DeleteManagementCluster.php
+++ b/app/Actions/DeleteManagementCluster.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions;
+
+use App\Contracts\BootstrapClusterService;
+use App\Models\ManagementCluster;
+
+final readonly class DeleteManagementCluster
+{
+    public function __construct(
+        private BootstrapClusterService $bootstrapService,
+    ) {}
+
+    public function handle(ManagementCluster $cluster): void
+    {
+        if ($this->bootstrapService->exists($cluster->name)) {
+            $this->bootstrapService->destroy($cluster->name);
+        }
+
+        $cluster->delete();
+    }
+}

--- a/app/Actions/MarkManagementClusterReady.php
+++ b/app/Actions/MarkManagementClusterReady.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions;
+
+use App\Enums\ManagementClusterStatus;
+use App\Models\ManagementCluster;
+
+final class MarkManagementClusterReady
+{
+    public function handle(ManagementCluster $cluster): void
+    {
+        $cluster->query()
+            ->whereKey($cluster->getKey())
+            ->update(['status' => ManagementClusterStatus::Ready]);
+    }
+}

--- a/app/Actions/WriteKubeconfigToTempFile.php
+++ b/app/Actions/WriteKubeconfigToTempFile.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions;
+
+use App\Contracts\KubeconfigReaderService;
+
+final readonly class WriteKubeconfigToTempFile
+{
+    public function __construct(
+        private KubeconfigReaderService $reader,
+    ) {}
+
+    public function handle(string $clusterName): string
+    {
+        $kubeconfig = $this->reader->read($clusterName);
+        $path = sys_get_temp_dir()."/{$clusterName}-kubeconfig";
+
+        file_put_contents($path, $kubeconfig);
+
+        return $path;
+    }
+}

--- a/app/Console/Commands/KuvenInitCommand.php
+++ b/app/Console/Commands/KuvenInitCommand.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Actions\CreateBootstrapCluster;
+use App\Actions\CreateManagementCluster;
+use App\Actions\DeleteManagementCluster;
+use App\Actions\InstallCapiControllers;
+use App\Actions\MarkManagementClusterReady;
+use App\Actions\StoreManagementKubeconfig;
+use App\Actions\ValidatePrerequisites;
+use App\Actions\WriteKubeconfigToTempFile;
+use App\Data\CreateManagementClusterData;
+use App\Queries\ManagementClusterQuery;
+use Illuminate\Console\Command;
+
+final class KuvenInitCommand extends Command
+{
+    /** @var string */
+    protected $signature = 'kuven:init
+        {--provider= : Infrastructure provider (docker, hetzner)}
+        {--region=local : Region for the management cluster}
+        {--force : Re-bootstrap even if a management cluster already exists}';
+
+    /** @var string */
+    protected $description = 'Bootstrap a CAPI management cluster';
+
+    public function handle(
+        ManagementClusterQuery $managementClusterQuery,
+        ValidatePrerequisites $validatePrerequisites,
+        CreateManagementCluster $createManagementCluster,
+        DeleteManagementCluster $deleteManagementCluster,
+        CreateBootstrapCluster $createBootstrapCluster,
+        InstallCapiControllers $installCapiControllers,
+        WriteKubeconfigToTempFile $writeKubeconfigToTempFile,
+        StoreManagementKubeconfig $storeManagementKubeconfig,
+        MarkManagementClusterReady $markManagementClusterReady,
+    ): int {
+        $provider = $this->option('provider');
+
+        if (! is_string($provider) || $provider === '') {
+            $this->components->error('The --provider option is required (e.g. --provider=docker).');
+
+            return self::FAILURE;
+        }
+
+        /** @var string $region */
+        $region = $this->option('region');
+
+        $force = (bool) $this->option('force');
+
+        $existing = ($managementClusterQuery)()->byProvider($provider)->byRegion($region)->first();
+
+        if ($existing && ! $force) {
+            $this->components->error("Management cluster for provider [{$provider}] in region [{$region}] already exists. Use --force to re-bootstrap.");
+
+            return self::FAILURE;
+        }
+
+        if ($existing) {
+            $deleteManagementCluster->handle($existing);
+        }
+
+        $result = $validatePrerequisites->handle();
+
+        if (! $result->ok) {
+            $this->components->error('Missing prerequisites: '.implode(', ', $result->missing));
+
+            return self::FAILURE;
+        }
+
+        $cluster = $createManagementCluster->handle(new CreateManagementClusterData(
+            name: "kuven-mgmt-{$region}",
+            provider: $provider,
+            region: $region,
+        ));
+
+        $this->components->info('Creating bootstrap cluster...');
+        $createBootstrapCluster->handle($cluster->name);
+
+        $this->components->info('Writing kubeconfig...');
+        $kubeconfigPath = $writeKubeconfigToTempFile->handle($cluster->name);
+
+        $this->components->info('Installing CAPI controllers...');
+        $installCapiControllers->handle($provider, $kubeconfigPath);
+
+        $this->components->info('Storing management cluster kubeconfig...');
+        $storeManagementKubeconfig->handle($cluster, $cluster->name);
+
+        @unlink($kubeconfigPath);
+
+        $markManagementClusterReady->handle($cluster);
+
+        $this->components->info("Management cluster [{$cluster->name}] is ready.");
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Data/CreateManagementClusterData.php
+++ b/app/Data/CreateManagementClusterData.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Data;
+
+final readonly class CreateManagementClusterData
+{
+    public function __construct(
+        public string $name,
+        public string $provider,
+        public string $region,
+    ) {}
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -12,10 +12,18 @@ use App\Client\HttpServerClient;
 use App\Client\LarakubeClient;
 use App\Console\Services\SessionManager;
 use App\Contracts\AuthClient;
+use App\Contracts\BootstrapClusterService;
+use App\Contracts\CapiInstallerService;
 use App\Contracts\CloudProviderClient;
 use App\Contracts\InfrastructureClient;
+use App\Contracts\KubeconfigReaderService;
 use App\Contracts\OrganizationClient;
+use App\Contracts\PrerequisiteChecker;
 use App\Contracts\ServerClient;
+use App\Services\ClusterctlCapiInstallerService;
+use App\Services\KindBootstrapClusterService;
+use App\Services\KindKubeconfigReaderService;
+use App\Services\ProcessPrerequisiteChecker;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\ServiceProvider;
@@ -54,6 +62,11 @@ final class AppServiceProvider extends ServiceProvider
         $this->app->bind(CloudProviderClient::class, HttpCloudProviderClient::class);
         $this->app->bind(InfrastructureClient::class, HttpInfrastructureClient::class);
         $this->app->bind(ServerClient::class, HttpServerClient::class);
+
+        $this->app->bind(PrerequisiteChecker::class, ProcessPrerequisiteChecker::class);
+        $this->app->bind(BootstrapClusterService::class, KindBootstrapClusterService::class);
+        $this->app->bind(CapiInstallerService::class, ClusterctlCapiInstallerService::class);
+        $this->app->bind(KubeconfigReaderService::class, KindKubeconfigReaderService::class);
     }
 
     /**

--- a/app/Queries/ManagementClusterQuery.php
+++ b/app/Queries/ManagementClusterQuery.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Queries;
+
+use App\Models\ManagementCluster;
+use Illuminate\Database\Eloquent\Builder;
+
+final class ManagementClusterQuery
+{
+    /** @var Builder<ManagementCluster> */
+    private Builder $builder;
+
+    public function __invoke(): self
+    {
+        $this->builder = ManagementCluster::query();
+
+        return clone $this;
+    }
+
+    public function byProvider(string $provider): self
+    {
+        $this->builder->where('provider', $provider);
+
+        return $this;
+    }
+
+    public function byRegion(string $region): self
+    {
+        $this->builder->where('region', $region);
+
+        return $this;
+    }
+
+    public function first(): ?ManagementCluster
+    {
+        return $this->builder->first();
+    }
+}

--- a/app/Services/ClusterctlCapiInstallerService.php
+++ b/app/Services/ClusterctlCapiInstallerService.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Contracts\CapiInstallerService;
+use Illuminate\Support\Facades\Process;
+use RuntimeException;
+
+/** @codeCoverageIgnore */
+final class ClusterctlCapiInstallerService implements CapiInstallerService
+{
+    public function init(string $provider, string $kubeconfig): void
+    {
+        $result = Process::run("clusterctl init --infrastructure {$provider} --kubeconfig {$kubeconfig}");
+
+        if ($result->failed()) {
+            throw new RuntimeException("Failed to install CAPI controllers: {$result->errorOutput()}");
+        }
+    }
+}

--- a/app/Services/KindBootstrapClusterService.php
+++ b/app/Services/KindBootstrapClusterService.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Contracts\BootstrapClusterService;
+use Illuminate\Support\Facades\Process;
+use RuntimeException;
+
+/** @codeCoverageIgnore */
+final class KindBootstrapClusterService implements BootstrapClusterService
+{
+    public function create(string $name): void
+    {
+        $result = Process::run("kind create cluster --name {$name}");
+
+        if ($result->failed()) {
+            throw new RuntimeException("Failed to create kind cluster '{$name}': {$result->errorOutput()}");
+        }
+    }
+
+    public function destroy(string $name): void
+    {
+        $result = Process::run("kind delete cluster --name {$name}");
+
+        if ($result->failed()) {
+            throw new RuntimeException("Failed to delete kind cluster '{$name}': {$result->errorOutput()}");
+        }
+    }
+
+    public function exists(string $name): bool
+    {
+        $result = Process::run('kind get clusters');
+
+        if ($result->failed()) {
+            return false;
+        }
+
+        $clusters = array_filter(explode("\n", $result->output()));
+
+        return in_array($name, $clusters, true);
+    }
+}

--- a/app/Services/KindKubeconfigReaderService.php
+++ b/app/Services/KindKubeconfigReaderService.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Contracts\KubeconfigReaderService;
+use Illuminate\Support\Facades\Process;
+use RuntimeException;
+
+/** @codeCoverageIgnore */
+final class KindKubeconfigReaderService implements KubeconfigReaderService
+{
+    public function read(string $clusterName): string
+    {
+        $result = Process::run("kind get kubeconfig --name {$clusterName}");
+
+        if ($result->failed()) {
+            throw new RuntimeException("Failed to read kubeconfig for cluster '{$clusterName}': {$result->errorOutput()}");
+        }
+
+        return $result->output();
+    }
+}

--- a/app/Services/ProcessPrerequisiteChecker.php
+++ b/app/Services/ProcessPrerequisiteChecker.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Contracts\PrerequisiteChecker;
+use Illuminate\Process\PendingProcess;
+use Illuminate\Support\Facades\Process;
+
+/** @codeCoverageIgnore */
+final class ProcessPrerequisiteChecker implements PrerequisiteChecker
+{
+    public function hasBinary(string $name): bool
+    {
+        return $this->run("command -v {$name}")->successful();
+    }
+
+    public function isDockerRunning(): bool
+    {
+        return $this->hasBinary('docker') && $this->run('docker info')->successful();
+    }
+
+    private function run(string $command): \Illuminate\Contracts\Process\ProcessResult
+    {
+        return Process::quietly()->run($command);
+    }
+}

--- a/tests/Feature/Commands/KuvenInitCommandTest.php
+++ b/tests/Feature/Commands/KuvenInitCommandTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Contracts\BootstrapClusterService;
+use App\Contracts\CapiInstallerService;
+use App\Contracts\KubeconfigReaderService;
+use App\Contracts\PrerequisiteChecker;
+use App\Enums\ManagementClusterStatus;
+use App\Models\ManagementCluster;
+use App\Services\InMemory\InMemoryBootstrapClusterService;
+use App\Services\InMemory\InMemoryCapiInstallerService;
+use App\Services\InMemory\InMemoryKubeconfigReaderService;
+use App\Services\InMemory\InMemoryPrerequisiteChecker;
+
+beforeEach(function (): void {
+    $this->prereqs = new InMemoryPrerequisiteChecker;
+    $this->prereqs->setAvailable(['kind', 'clusterctl', 'kubectl', 'docker']);
+
+    $this->bootstrap = new InMemoryBootstrapClusterService;
+
+    $this->capi = new InMemoryCapiInstallerService;
+
+    $this->kubeconfig = new InMemoryKubeconfigReaderService;
+    $this->kubeconfig->setKubeconfig('kuven-mgmt-local', 'apiVersion: v1\nclusters: []');
+
+    $this->app->instance(PrerequisiteChecker::class, $this->prereqs);
+    $this->app->instance(BootstrapClusterService::class, $this->bootstrap);
+    $this->app->instance(CapiInstallerService::class, $this->capi);
+    $this->app->instance(KubeconfigReaderService::class, $this->kubeconfig);
+});
+
+test('bootstraps a local management cluster',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        $this->artisan('kuven:init', ['--provider' => 'docker'])
+            ->assertSuccessful();
+
+        /** @var ManagementCluster $cluster */
+        $cluster = ManagementCluster::query()->sole();
+
+        expect($cluster->provider)->toBe('docker')
+            ->and($cluster->region)->toBe('local')
+            ->and($cluster->status)->toBe(ManagementClusterStatus::Ready)
+            ->and($cluster->kubeconfig)->not->toBeNull();
+    });
+
+test('aborts when management cluster already exists',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        ManagementCluster::factory()->ready()->create([
+            'provider' => 'docker',
+            'region' => 'local',
+        ]);
+
+        $this->artisan('kuven:init', ['--provider' => 'docker'])
+            ->expectsOutputToContain('already exists')
+            ->assertFailed();
+    });
+
+test('re-bootstraps with force flag',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        $existing = ManagementCluster::factory()->ready()->create([
+            'name' => 'kuven-mgmt-local',
+            'provider' => 'docker',
+            'region' => 'local',
+        ]);
+
+        $this->bootstrap->addCluster($existing->name);
+
+        $this->artisan('kuven:init', ['--provider' => 'docker', '--force' => true])
+            ->assertSuccessful();
+
+        expect(ManagementCluster::query()->count())->toBe(1);
+
+        /** @var ManagementCluster $cluster */
+        $cluster = ManagementCluster::query()->sole();
+
+        expect($cluster->status)->toBe(ManagementClusterStatus::Ready);
+    });
+
+test('aborts when prerequisites are missing',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        $this->prereqs->setAvailable(['kind', 'kubectl', 'docker']);
+
+        $this->artisan('kuven:init', ['--provider' => 'docker'])
+            ->expectsOutputToContain('clusterctl')
+            ->assertFailed();
+
+        expect(ManagementCluster::query()->count())->toBe(0);
+    });
+
+test('uses custom region when provided',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        $this->kubeconfig->setKubeconfig('kuven-mgmt-nuremberg', 'apiVersion: v1\nclusters: []');
+
+        $this->artisan('kuven:init', ['--provider' => 'docker', '--region' => 'nuremberg'])
+            ->assertSuccessful();
+
+        /** @var ManagementCluster $cluster */
+        $cluster = ManagementCluster::query()->sole();
+
+        expect($cluster->region)->toBe('nuremberg');
+    });
+
+test('aborts when provider option is missing',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        $this->artisan('kuven:init')
+            ->expectsOutputToContain('--provider option is required')
+            ->assertFailed();
+    });


### PR DESCRIPTION
## Summary

`php artisan kuven:init --provider=docker` bootstraps a local CAPI management cluster.

**Command flow:**
1. Validate `--provider` is provided
2. Idempotency check via `ManagementClusterQuery` (abort if exists, unless `--force`)
3. `--force` deletes existing record + kind cluster via `DeleteManagementCluster`
4. Validate prerequisites via `ValidatePrerequisites`
5. Create `ManagementCluster` record via `CreateManagementCluster` action + `CreateManagementClusterData` DTO
6. Create kind cluster via `CreateBootstrapCluster`
7. Write kubeconfig to temp file via `WriteKubeconfigToTempFile`
8. Install CAPI controllers via `InstallCapiControllers`
9. Store encrypted kubeconfig via `StoreManagementKubeconfig`
10. Mark cluster ready via `MarkManagementClusterReady`

**New components:**
- Actions: `CreateManagementCluster`, `DeleteManagementCluster`, `MarkManagementClusterReady`, `WriteKubeconfigToTempFile`
- Data: `CreateManagementClusterData`
- Query: `ManagementClusterQuery`
- Real implementations: `ProcessPrerequisiteChecker`, `KindBootstrapClusterService`, `ClusterctlCapiInstallerService`, `KindKubeconfigReaderService` (`@codeCoverageIgnore` — tested via InMemory doubles)
- Bindings in `AppServiceProvider`

Closes #141, closes #107

**Follow-up:** #145 — refactor to use authenticated HTTP client pattern for production use

## Test plan
- [x] 1005 tests pass, 100% coverage
- [x] 6 command tests: bootstrap, idempotency, force, missing prerequisites, custom region, missing provider
- [x] Tested manually: `php artisan kuven:init --provider=docker` creates kind cluster with CAPD

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new CLI command to bootstrap and initialize a management cluster with support for specifying infrastructure providers and geographic regions. The command includes a force flag to allow re-bootstrapping of existing configurations.

* **Tests**
  * Added comprehensive test coverage for the cluster initialization command, validating various scenarios and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->