### PR TITLE
fix: pass email scope to RegistrationFeature check

### DIFF
--- a/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -42,7 +42,7 @@ final class RegisteredUserController extends Controller
             'password' => ['required', 'confirmed', Rules\Password::defaults()],
         ]);
 
-        if (! Feature::active(RegistrationFeature::class)) {
+        if (! Feature::for($request->string('email')->toString())->active(RegistrationFeature::class)) {
             throw ValidationException::withMessages([
                 'email' => 'Registration is not available yet. Join the waitlist at kuven.io for early access.',
             ]);

--- a/tests/Feature/Features/AuthFeatureGatesTest.php
+++ b/tests/Feature/Features/AuthFeatureGatesTest.php
@@ -69,7 +69,7 @@ test('registration succeeds when feature is active', function (): void {
 });
 
 test('registration returns validation error when feature is inactive', function (): void {
-    Feature::deactivate(RegistrationFeature::class);
+    Feature::for('test@example.com')->deactivate(RegistrationFeature::class);
 
     $this->post('/register', [
         'name' => 'Test User',


### PR DESCRIPTION
## Summary

PR #162 (PlatformRole) overwrote the registration controller changes from PR #152 (allowed emails). The `Feature::active(RegistrationFeature::class)` call lost the email scope parameter, so the allowlist was never checked.

One-line fix: restore `$request->string('email')->toString()` as the second argument.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Registration availability is now determined per email address, so whether you can register may vary depending on the email you provide.

* **Tests**
  * Automated tests updated to validate the new per-email registration gating behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->