### PR TITLE
feat: ProvisionTenantNamespace action

### DIFF
--- a/app/Actions/ProvisionTenantNamespace.php
+++ b/app/Actions/ProvisionTenantNamespace.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions;
+
+use App\Http\Integrations\Kubernetes\Data\RuleData;
+use App\Http\Integrations\Kubernetes\KubernetesConnector;
+use App\Http\Integrations\Kubernetes\Requests\CreateNamespace;
+use App\Http\Integrations\Kubernetes\Requests\CreateRole;
+use App\Http\Integrations\Kubernetes\Requests\CreateRoleBinding;
+use App\Http\Integrations\Kubernetes\Requests\CreateServiceAccount;
+use App\Models\Organization;
+
+final class ProvisionTenantNamespace
+{
+    private const SERVICE_ACCOUNT_NAME = 'kuven-operator';
+
+    private const ROLE_NAME = 'kuven-operator';
+
+    public function handle(KubernetesConnector $connector, Organization $organization): void
+    {
+        $namespace = "kuven-org-{$organization->id}";
+
+        $connector->send(new CreateNamespace($namespace));
+
+        $connector->send(new CreateServiceAccount(
+            name: self::SERVICE_ACCOUNT_NAME,
+            namespace: $namespace,
+        ));
+
+        $connector->send(new CreateRole(
+            name: self::ROLE_NAME,
+            namespace: $namespace,
+            rules: $this->capiRules(),
+        ));
+
+        $connector->send(new CreateRoleBinding(
+            name: self::ROLE_NAME,
+            namespace: $namespace,
+            roleName: self::ROLE_NAME,
+            serviceAccountName: self::SERVICE_ACCOUNT_NAME,
+        ));
+    }
+
+    /**
+     * @return list<RuleData>
+     */
+    private function capiRules(): array
+    {
+        return [
+            new RuleData(
+                apiGroups: ['cluster.x-k8s.io', 'infrastructure.cluster.x-k8s.io', 'bootstrap.cluster.x-k8s.io', 'controlplane.cluster.x-k8s.io'],
+                resources: ['*'],
+                verbs: ['*'],
+            ),
+            new RuleData(
+                apiGroups: [''],
+                resources: ['secrets', 'configmaps'],
+                verbs: ['*'],
+            ),
+        ];
+    }
+}

--- a/tests/Unit/Actions/ProvisionTenantNamespaceTest.php
+++ b/tests/Unit/Actions/ProvisionTenantNamespaceTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\ProvisionTenantNamespace;
+use App\Http\Integrations\Kubernetes\KubernetesConnector;
+use App\Http\Integrations\Kubernetes\Requests\CreateNamespace;
+use App\Http\Integrations\Kubernetes\Requests\CreateRole;
+use App\Http\Integrations\Kubernetes\Requests\CreateRoleBinding;
+use App\Http\Integrations\Kubernetes\Requests\CreateServiceAccount;
+use App\Models\Organization;
+use Saloon\Http\Faking\MockClient;
+use Saloon\Http\Faking\MockResponse;
+
+beforeEach(function (): void {
+    $this->connector = new KubernetesConnector(
+        server: 'https://127.0.0.1:60517',
+        token: 'test-token',
+        verifySsl: false,
+    );
+
+    $this->action = app(ProvisionTenantNamespace::class);
+});
+
+test('provisions namespace, service account, role, and role binding',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var Organization $organization */
+        $organization = Organization::factory()->create();
+
+        $mockClient = new MockClient([
+            CreateNamespace::class => MockResponse::fixture('kubernetes/create-namespace'),
+            CreateServiceAccount::class => MockResponse::fixture('kubernetes/create-service-account'),
+            CreateRole::class => MockResponse::fixture('kubernetes/create-role'),
+            CreateRoleBinding::class => MockResponse::fixture('kubernetes/create-role-binding'),
+        ]);
+
+        $this->connector->withMockClient($mockClient);
+
+        $this->action->handle($this->connector, $organization);
+
+        $mockClient->assertSentCount(4);
+        $mockClient->assertSent(CreateNamespace::class);
+        $mockClient->assertSent(CreateServiceAccount::class);
+        $mockClient->assertSent(CreateRole::class);
+        $mockClient->assertSent(CreateRoleBinding::class);
+    });
+
+test('builds namespace name from organization id',
+    /**
+     * @throws Throwable
+     */
+    function (): void {
+        /** @var Organization $organization */
+        $organization = Organization::factory()->create();
+
+        $mockClient = new MockClient([
+            CreateNamespace::class => MockResponse::fixture('kubernetes/create-namespace'),
+            CreateServiceAccount::class => MockResponse::fixture('kubernetes/create-service-account'),
+            CreateRole::class => MockResponse::fixture('kubernetes/create-role'),
+            CreateRoleBinding::class => MockResponse::fixture('kubernetes/create-role-binding'),
+        ]);
+
+        $this->connector->withMockClient($mockClient);
+
+        $this->action->handle($this->connector, $organization);
+
+        $mockClient->assertSent(CreateNamespace::class);
+    });


### PR DESCRIPTION
## Summary

Action that provisions RBAC-isolated tenant namespace on the management cluster:

1. **Namespace** — `kuven-org-{organization_id}`
2. **ServiceAccount** — `kuven-operator` scoped to namespace
3. **Role** — CAPI resource access (cluster.x-k8s.io, infrastructure, bootstrap, controlplane) + secrets/configmaps
4. **RoleBinding** — binds ServiceAccount to Role

Accepts a `KubernetesConnector` and `Organization` — the caller creates the connector from the management cluster kubeconfig.

@see ADR-0008

Part 1 of 3 for #108

## Test plan
- [x] All tests pass, 100% coverage
- [x] Verifies all 4 K8s resources are created via MockClient assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Kubernetes RBAC resources for tenant environments are now automatically provisioned with service accounts, roles, and permission bindings configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->