### PR TITLE
feat: management cluster detail view with sidenav

### DIFF
--- a/app/Http/Controllers/Admin/ManagementClusterController.php
+++ b/app/Http/Controllers/Admin/ManagementClusterController.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace App\Http\Controllers\Admin;
 
 use App\Http\Requests\Admin\IndexManagementClusterRequest;
+use App\Http\Requests\Admin\ShowManagementClusterRequest;
 use App\Http\Resources\ManagementClusterResource;
+use App\Models\ManagementCluster;
 use App\Queries\ManagementClusterQuery;
 use Inertia\Inertia;
 use Inertia\Response;
@@ -18,6 +20,13 @@ final class ManagementClusterController
 
         return Inertia::render('admin/management-clusters/index', [
             'clusters' => ManagementClusterResource::collection($clusters)->resolve(),
+        ]);
+    }
+
+    public function show(ShowManagementClusterRequest $request, ManagementCluster $managementCluster): Response
+    {
+        return Inertia::render('admin/management-clusters/show', [
+            'cluster' => (new ManagementClusterResource($managementCluster))->resolve(),
         ]);
     }
 }

--- a/app/Http/Requests/Admin/ShowManagementClusterRequest.php
+++ b/app/Http/Requests/Admin/ShowManagementClusterRequest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Admin;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+final class ShowManagementClusterRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user()->can('view', $this->route('management_cluster'));
+    }
+
+    /**
+     * @return array<string, array<int, string>>
+     */
+    public function rules(): array
+    {
+        return [];
+    }
+}

--- a/resources/js/pages/admin/management-clusters/index.tsx
+++ b/resources/js/pages/admin/management-clusters/index.tsx
@@ -3,7 +3,7 @@ import { Button } from '@/components/ui/button';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
 import { Empty, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from '@/components/ui/empty';
 import AppLayout from '@/layouts/app-layout';
-import { Head } from '@inertiajs/react';
+import { Head, Link } from '@inertiajs/react';
 import { SiDigitalocean, SiDocker, SiHetzner, SiKubernetes } from '@icons-pack/react-simple-icons';
 import { Cloud, Layers, MapPin, MoreHorizontal, Settings, Terminal, Trash2 } from 'lucide-react';
 
@@ -86,9 +86,10 @@ export default function Index({ clusters }: ManagementClustersPageProps) {
                 ) : (
                     <div className="flex flex-col gap-3">
                         {clusters.map((cluster) => (
-                            <div
+                            <Link
                                 key={cluster.id}
-                                className="rounded-lg border bg-card p-4 transition-colors hover:bg-muted/30"
+                                href={`/admin/management-clusters/${cluster.id}`}
+                                className="block rounded-lg border bg-card p-4 transition-colors hover:bg-muted/30"
                             >
                                 <div className="flex items-center justify-between">
                                     <div className="flex items-center gap-3">
@@ -143,7 +144,7 @@ export default function Index({ clusters }: ManagementClustersPageProps) {
                                         0 tenant clusters
                                     </span>
                                 </div>
-                            </div>
+                            </Link>
                         ))}
                     </div>
                 )}

--- a/resources/js/pages/admin/management-clusters/show.tsx
+++ b/resources/js/pages/admin/management-clusters/show.tsx
@@ -1,0 +1,181 @@
+import { Badge } from '@/components/ui/badge';
+import AppLayout from '@/layouts/app-layout';
+import { cn } from '@/lib/utils';
+import { Head, Link } from '@inertiajs/react';
+import { SiDigitalocean, SiDocker, SiHetzner, SiKubernetes } from '@icons-pack/react-simple-icons';
+import { Cloud, Layers, MapPin, Server } from 'lucide-react';
+
+interface ManagementCluster {
+    id: string;
+    name: string;
+    provider: string;
+    region: string;
+    status: string;
+    kubernetes_version: string;
+    created_at: string;
+}
+
+interface ShowManagementClusterPageProps {
+    cluster: ManagementCluster;
+}
+
+const STATUS_DOT_COLORS: Record<string, string> = {
+    ready: 'bg-emerald-500',
+    bootstrapping: 'bg-amber-500',
+    failed: 'bg-destructive',
+};
+
+const REGION_LABELS: Record<string, string> = {
+    'eu-central': 'EU Central (Frankfurt)',
+    'us-east': 'US East (Virginia)',
+    'us-west': 'US West (Oregon)',
+    'ap-southeast': 'AP Southeast (Singapore)',
+    local: 'Local',
+};
+
+const PROVIDER_CONFIG: Record<string, { icon: React.ReactNode; bg: string; color: string; label: string }> = {
+    hetzner: { icon: <SiHetzner className="size-[18px]" />, bg: 'bg-[#d50c2d]', color: 'text-white', label: 'Hetzner' },
+    docker: { icon: <SiDocker className="size-[18px]" />, bg: 'bg-[#2496ed]', color: 'text-white', label: 'Docker' },
+    digital_ocean: { icon: <SiDigitalocean className="size-[18px]" />, bg: 'bg-[#0080ff]', color: 'text-white', label: 'DigitalOcean' },
+};
+
+const NAV_ITEMS = [
+    { title: 'Overview', section: 'overview' },
+    { title: 'Tenant Clusters', section: 'tenant-clusters' },
+    { title: 'Monitoring', section: 'monitoring' },
+    { title: 'Logs', section: 'logs' },
+    { title: 'Danger Zone', section: 'danger-zone' },
+];
+
+function ProviderLogo({ provider }: { provider: string }) {
+    const config = PROVIDER_CONFIG[provider];
+
+    if (!config) {
+        return (
+            <div className="bg-muted flex size-9 shrink-0 items-center justify-center rounded-lg">
+                <Cloud className="text-muted-foreground size-4" />
+            </div>
+        );
+    }
+
+    return (
+        <div className={`flex size-9 shrink-0 items-center justify-center rounded-lg ${config.bg} ${config.color}`}>
+            {config.icon}
+        </div>
+    );
+}
+
+function DetailRow({ icon, label, value }: { icon: React.ReactNode; label: string; value: React.ReactNode }) {
+    return (
+        <div className="flex items-center justify-between py-3">
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                {icon}
+                {label}
+            </div>
+            <div className="text-sm font-medium">{value}</div>
+        </div>
+    );
+}
+
+export default function Show({ cluster }: ShowManagementClusterPageProps) {
+    const currentSection = 'overview';
+    const providerConfig = PROVIDER_CONFIG[cluster.provider];
+
+    return (
+        <AppLayout>
+            <Head title={cluster.name} />
+            <div className="flex items-start justify-center px-7">
+                {/* Left sidebar */}
+                <div className="sticky top-[calc(var(--header-height,56px)+2.5rem)] w-56 shrink-0 pt-6">
+                    <div className="space-y-5">
+                        <div>
+                            <Link
+                                href="/admin/management-clusters"
+                                className="text-muted-foreground hover:text-foreground text-xs transition-colors"
+                            >
+                                &larr; All clusters
+                            </Link>
+                            <h2 className="text-foreground mt-2 pl-3 text-xl/8 font-medium">{cluster.name}</h2>
+                        </div>
+                        <nav className="space-y-1">
+                            {NAV_ITEMS.map((item) => (
+                                <button
+                                    key={item.section}
+                                    className={cn(
+                                        'hover:bg-accent flex w-full items-center gap-2 rounded-md px-3 py-2 text-sm focus:outline-hidden',
+                                        currentSection === item.section
+                                            ? 'bg-accent text-foreground font-medium'
+                                            : 'text-muted-foreground',
+                                    )}
+                                >
+                                    {item.title}
+                                </button>
+                            ))}
+                        </nav>
+                    </div>
+                </div>
+
+                {/* Main content */}
+                <div className="mt-8 w-[calc(768px+6rem)] max-w-none pt-6 pr-0 pb-20 pl-6 xl:px-12">
+                    <div className="mx-auto flex w-full items-start justify-center">
+                        <div className="w-full space-y-6">
+                            {/* Header card */}
+                            <div className="rounded-lg border bg-card p-6">
+                                <div className="flex items-center gap-4">
+                                    <ProviderLogo provider={cluster.provider} />
+                                    <div className="flex-1">
+                                        <h1 className="text-lg font-semibold">{cluster.name}</h1>
+                                        <p className="text-muted-foreground text-sm">
+                                            {providerConfig?.label ?? cluster.provider} management cluster
+                                        </p>
+                                    </div>
+                                    <Badge variant="outline" className="gap-1.5">
+                                        <div className={`size-2 rounded-full ${STATUS_DOT_COLORS[cluster.status] ?? 'bg-muted-foreground'}`} />
+                                        {cluster.status}
+                                    </Badge>
+                                </div>
+                            </div>
+
+                            {/* Details */}
+                            <div className="rounded-lg border bg-card">
+                                <div className="border-b px-6 py-4">
+                                    <h2 className="text-sm font-medium">Cluster Details</h2>
+                                </div>
+                                <div className="divide-y px-6">
+                                    <DetailRow
+                                        icon={<Server className="size-4" />}
+                                        label="Provider"
+                                        value={providerConfig?.label ?? cluster.provider}
+                                    />
+                                    <DetailRow
+                                        icon={<MapPin className="size-4" />}
+                                        label="Region"
+                                        value={REGION_LABELS[cluster.region] ?? cluster.region}
+                                    />
+                                    <DetailRow
+                                        icon={<SiKubernetes className="size-4" />}
+                                        label="Kubernetes Version"
+                                        value={cluster.kubernetes_version}
+                                    />
+                                    <DetailRow
+                                        icon={<Layers className="size-4" />}
+                                        label="Tenant Clusters"
+                                        value="0"
+                                    />
+                                    <DetailRow
+                                        icon={<Cloud className="size-4" />}
+                                        label="Created"
+                                        value={new Date(cluster.created_at).toLocaleDateString()}
+                                    />
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                {/* Right spacer */}
+                <div className="hidden w-full max-w-56 xl:block" />
+            </div>
+        </AppLayout>
+    );
+}

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -11,5 +11,6 @@ Route::middleware(['auth', 'verified'])
     ->group(function () {
         Route::prefix('management-clusters')->as('management-clusters.')->group(function () {
             Route::get('/', [ManagementClusterController::class, 'index'])->name('index');
+            Route::get('/{management_cluster}', [ManagementClusterController::class, 'show'])->name('show');
         });
     });

--- a/tests/Feature/AdminManagementClusterTest.php
+++ b/tests/Feature/AdminManagementClusterTest.php
@@ -60,3 +60,49 @@ test('a guest is redirected to login when accessing management clusters', functi
     $this->get(route('admin.management-clusters.index'))
         ->assertRedirect(route('login'));
 });
+
+test('a platform administrator can view a single management cluster', function () {
+    /** @var User $admin */
+    $admin = User::factory()->create(['platform_role' => PlatformRole::Admin]);
+
+    /** @var ManagementCluster $cluster */
+    $cluster = ManagementCluster::factory()->ready()->create([
+        'name' => 'mgmt-production',
+        'provider' => 'hetzner',
+        'region' => 'eu-central',
+    ]);
+
+    $this->actingAs($admin)
+        ->get(route('admin.management-clusters.show', $cluster))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page
+            ->component('admin/management-clusters/show')
+            ->where('cluster.id', $cluster->id)
+            ->where('cluster.name', 'mgmt-production')
+            ->where('cluster.provider', 'hetzner')
+            ->where('cluster.region', 'eu-central')
+            ->where('cluster.status', ManagementClusterStatus::Ready->value)
+            ->where('cluster.kubernetes_version', 'v1.32.3')
+            ->has('cluster.created_at')
+        );
+});
+
+test('a non-platform administrator is forbidden from viewing a management cluster', function () {
+    /** @var User $user */
+    $user = User::factory()->create(['platform_role' => PlatformRole::Member]);
+
+    /** @var ManagementCluster $cluster */
+    $cluster = ManagementCluster::factory()->ready()->create();
+
+    $this->actingAs($user)
+        ->get(route('admin.management-clusters.show', $cluster))
+        ->assertForbidden();
+});
+
+test('a guest is redirected to login when viewing a management cluster', function () {
+    /** @var ManagementCluster $cluster */
+    $cluster = ManagementCluster::factory()->ready()->create();
+
+    $this->get(route('admin.management-clusters.show', $cluster))
+        ->assertRedirect(route('login'));
+});


### PR DESCRIPTION
## Summary

Closes #158

- Add `show` route and `ShowManagementClusterRequest` with `ManagementClusterPolicy::view` authorization
- Detail page with settings-style sidenav (Overview, Tenant Clusters, Monitoring, Logs, Danger Zone — placeholders)
- Header card with provider logo, name, and status badge
- Cluster details section: provider, region, Kubernetes version, tenant clusters count, created date
- Back link to cluster list; list cards now link to detail view

## Test plan

- [x] Admin can view a single management cluster with all props
- [x] Non-admin gets 403
- [x] Guest redirects to login
- [x] Full test suite passes (1058 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)